### PR TITLE
Ensure that glob("prefix/*") works as expected

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -455,7 +455,7 @@ class S3FileSystem(AsyncFileSystem):
         #     elif len(out) == 0:
         #         return super().find(path)
         #     # else: we refresh anyway, having at least two missing trees
-        out = await self._lsdir(path, delimiter="")
+        out = await self._lsdir(path, delimiter="/" if withdirs else "")
         if not out and key:
             try:
                 out = [await self._info(path)]


### PR DESCRIPTION
dask dataframe uses fs.glob("prefix/*") in parts of the pyarrow read path
This requires us to pass the delimiter to find to ensure that the directory
entries get returned.

This manifests in the following example

Given a filesystem like

```
s3://prefix/table/key=1/part0001.parquet
s3://prefix/table/key=2/part0001.parquet
```

```python
dask.dataframe("s3://prefix/table", engine="pyarrow")
```

would fail