### PR TITLE
Support for S3 folder in s3fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 dist/
 *.egg-info
 build/
+venv*

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -295,9 +295,6 @@ class S3FileSystem(AsyncFileSystem):
         >>> split_path("s3://mybucket/path/to/file")
         ['mybucket', 'path/to/file', None]
 
-        >>> split_path("s3://mybucket/path/to/directory/")
-        ['mybucket', 'path/to/directory/', None]
-
         >>> split_path("s3://mybucket/path/to/versioned_file?versionId=some_version_id")
         ['mybucket', 'path/to/versioned_file', 'some_version_id']
         """
@@ -308,8 +305,6 @@ class S3FileSystem(AsyncFileSystem):
         else:
             bucket, keypart = path.split("/", 1)
             key, _, version_id = keypart.partition("?versionId=")
-            # retain trailing "/" from original path (s3 treats it for directory)
-            key = key + "/" if path.endswith("/") else key
             return (
                 bucket,
                 key,

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -636,6 +636,19 @@ class S3FileSystem(AsyncFileSystem):
             return
 
         try:
+            """
+            https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html
+            
+            The Amazon S3 console treats all objects that have a 
+            forward slash "/" character as the last (trailing) 
+            character in the key name as a folder, for example 
+            examplekeyname/. You can't upload an object that has a 
+            key name with a trailing "/" character using the Amazon 
+            S3 console. However, you can upload objects that are 
+            named with a trailing "/" with the Amazon S3 API by 
+            using the AWS CLI, AWS SDKs, or REST API.
+            """
+
             folder_key = key.rstrip("/") + "/"
             write_result = self.call_s3(
                 self.s3.put_object, kwargs, Bucket=bucket, Key=folder_key

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -509,11 +509,9 @@ class S3FileSystem(AsyncFileSystem):
                 async for i in it:
                     dircache.extend(i.get("CommonPrefixes", []))
                     for c in i.get("Contents", []):
-                        if c['Key'].endswith('/'):
-                            if c['Key'] != prefix:
-                                dircache.append(
-                                    {'Prefix': c['Key']}
-                                )
+                        if c["Key"].endswith("/"):
+                            if c["Key"] != prefix:
+                                dircache.append({"Prefix": c["Key"]})
                         else:
                             c["type"] = "file"
                             c["size"] = c["Size"]
@@ -568,9 +566,11 @@ class S3FileSystem(AsyncFileSystem):
             try:
                 out = [await self._info(path)]
                 # exclude directories matching as `path` from the list
-                if len(out) == 1 \
-                        and out[0]['type'] == 'directory' \
-                        and out[0]['name'] == path:
+                if (
+                    len(out) == 1
+                    and out[0]["type"] == "directory"
+                    and out[0]["name"] == path
+                ):
                     out = []
             except FileNotFoundError:
                 out = []
@@ -633,14 +633,13 @@ class S3FileSystem(AsyncFileSystem):
         try:
             """
             https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html
-            
-            The Amazon S3 console treats all objects that have a 
-            forward slash "/" character as the last (trailing) 
-            character in the key name as a folder, for example 
-            examplekeyname/. You can't upload an object that has a 
-            key name with a trailing "/" character using the Amazon 
-            S3 console. However, you can upload objects that are 
-            named with a trailing "/" with the Amazon S3 API by 
+            The Amazon S3 console treats all objects that have a
+            forward slash "/" character as the last (trailing)
+            character in the key name as a folder, for example
+            examplekeyname/. You can't upload an object that has a
+            key name with a trailing "/" character using the Amazon
+            S3 console. However, you can upload objects that are
+            named with a trailing "/" with the Amazon S3 API by
             using the AWS CLI, AWS SDKs, or REST API.
             """
 
@@ -1459,7 +1458,7 @@ class S3FileSystem(AsyncFileSystem):
         objects = [{"Key": self.split_path(path)[1]} for path in pathlist]
 
         if dir_prefix:
-            objects = [{"Key": self.split_path(path)[1]+'/'} for path in pathlist]
+            objects = [{"Key": self.split_path(path)[1] + "/"} for path in pathlist]
 
         delete_keys = {
             "Objects": objects,
@@ -1484,8 +1483,7 @@ class S3FileSystem(AsyncFileSystem):
 
     async def _rm(self, paths, **kwargs):
         # if only path, then check for existence and do the right thing
-        if len(paths) == 1 and \
-                not self.exists(paths[0]):
+        if len(paths) == 1 and not self.exists(paths[0]):
             raise FileNotFoundError
 
         buckets = [p for p in paths if not self.split_path(p)[1]]
@@ -1495,14 +1493,14 @@ class S3FileSystem(AsyncFileSystem):
         # split files list for more than one bucket in the list
         await asyncio.gather(
             *[
-                self._bulk_delete(bucket_files[i: i + 1000])
+                self._bulk_delete(bucket_files[i : i + 1000])
                 for bucket_files in self.split_bucket_paths(files)
                 for i in range(0, len(bucket_files), 1000)
             ]
         )
         await asyncio.gather(
             *[
-                self._bulk_delete(dirs[i: i + 1000], dir_prefix=True)
+                self._bulk_delete(dirs[i : i + 1000], dir_prefix=True)
                 for i in range(0, len(dirs), 1000)
             ]
         )

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -734,7 +734,6 @@ class S3FileSystem(AsyncFileSystem):
             # the root always exists, even if anon
             return True
         bucket, key, version_id = self.split_path(path)
-
         if key:
             if path.endswith("/"):
                 key = key.rstrip("/") + "/"
@@ -911,7 +910,6 @@ class S3FileSystem(AsyncFileSystem):
     async def _info(self, path, bucket=None, key=None, kwargs={}, version_id=None):
         if bucket is None:
             bucket, key, version_id = self.split_path(path)
-
         try:
             out = await self._call_s3(
                 self.s3.head_object,

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -953,7 +953,7 @@ class S3FileSystem(AsyncFileSystem):
                 Bucket=bucket,
                 Prefix=key.rstrip("/") + "/",
                 Delimiter="/",
-                MaxKeys=2,
+                MaxKeys=1,
                 **self.req_kw,
             )
             if (

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -527,10 +527,12 @@ def test_rm(s3):
     s3.rm(a)
     assert not s3.exists(a)
     # the API is OK with deleting non-files; maybe this is an effect of using bulk
-    # with pytest.raises(FileNotFoundError):
-    #    s3.rm(test_bucket_name + '/nonexistent')
+    with pytest.raises(FileNotFoundError):
+        s3.rm(test_bucket_name + '/nonexistent')
+
     with pytest.raises(FileNotFoundError):
         s3.rm("nonexistent")
+
     s3.rm(test_bucket_name + "/nested", recursive=True)
     assert not s3.exists(test_bucket_name + "/nested/nested2/file1")
 
@@ -894,6 +896,8 @@ def test_new_bucket(s3):
         s3.rmdir("new")
 
     s3.rm("new/temp")
+    assert not s3.exists("new/temp")
+    assert s3.exists("new")
     s3.rmdir("new")
     assert "new" not in s3.ls("")
     assert not s3.exists("new")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -578,6 +578,25 @@ def test_mkdir(s3):
     s3.mkdir(bucket)
     assert bucket in s3.ls("/")
 
+    s3.mkdir("test-bucket/foo/")
+    assert s3.exists("test-bucket/foo/")
+    assert s3.isdir("test-bucket/foo/")
+    assert not s3.isfile("test-bucket/foo/")
+    s3.touch("test-bucket/foo/bar")
+    assert s3.exists("test-bucket/foo/")
+
+    s3.mkdir("test-bucket/foo2")  # A missing trailing / is the only difference
+    assert s3.exists("test-bucket/foo2/")
+    assert s3.isdir("test-bucket/foo2/")
+    assert not s3.isfile("test-bucket/foo2/")
+    s3.touch("test-bucket/foo2/bar")
+    assert s3.exists("test-bucket/foo2/")
+
+    s3.touch("test-bucket/foo3/bar")
+    assert s3.exists("test-bucket/foo3/")
+    assert s3.isdir("test-bucket/foo3/")
+    assert not s3.isfile("test-bucket/foo3/")
+
 
 def test_mkdir_region_name(s3):
     bucket = "test2_bucket"

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -586,6 +586,45 @@ def test_bulk_delete(s3):
     filelist = s3.find(test_bucket_name + "/nested")
     s3.rm(filelist)
     assert not s3.exists(test_bucket_name + "/nested/nested2/file1")
+    s3.rm(test_bucket_name, recursive=True)
+
+    # delete multiple files and directory
+    s3.mkdir('test/dir1')
+
+    s3.touch('test/dir1/a.txt')
+    s3.touch('test/dir1/b.txt')
+    s3.touch('test/dir1/c.txt')
+
+    s3.touch('test/dir2/a.txt')
+    s3.touch('test/dir2/b.txt')
+    s3.touch('test/dir2/c.txt')
+
+    s3.mkdir('test/dir2/dir3')
+
+    s3.makedirs('test/dir5/dir6')
+
+    s3.makedirs('test2/dir7')
+
+    # new bucket
+    s3.touch('test2/dir7/something')
+
+    # multi-bucket bulk delete
+    s3.rm([
+        'test/dir2/a.txt',
+        'test/dir2/dir3',
+        'test2/dir7/something'
+    ])
+    assert s3.exists('test2')
+
+    assert len(s3.ls('test/dir2')) == 2
+
+    s3.rm('test/dir1', recursive=True)
+    assert not s3.exists('test/dir1')
+    assert len(s3.ls('test')) == 2
+    assert len(s3.ls('test/dir2')) == 2
+
+    s3.rm('test', recursive=True)
+    assert not s3.exists('test')
 
 
 @pytest.mark.xfail(reason="anon user is still priviliged on moto")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -412,23 +412,27 @@ def test_not_delegate():
 
 
 def test_split_path(s3):
-    assert s3.split_path(
-        "s3://mybucket/path/to/directory/"
-    ) == ('mybucket', 'path/to/directory', None)
+    assert s3.split_path("s3://mybucket/path/to/directory/") == (
+        "mybucket",
+        "path/to/directory",
+        None,
+    )
 
-    assert s3.split_path(
-        "s3://mybucket/path/to/file"
-    ) == ('mybucket', 'path/to/file', None)
+    assert s3.split_path("s3://mybucket/path/to/file") == (
+        "mybucket",
+        "path/to/file",
+        None,
+    )
 
     assert s3.split_path(
         "s3://mybucket/path/to/versioned_file?versionId=some_version_id"
-    ) == ('mybucket', 'path/to/versioned_file', None)
+    ) == ("mybucket", "path/to/versioned_file", None)
 
     s3.version_aware = True
 
     assert s3.split_path(
         "s3://mybucket/path/to/versioned_file?versionId=some_version_id"
-    ) == ('mybucket', 'path/to/versioned_file', 'some_version_id')
+    ) == ("mybucket", "path/to/versioned_file", "some_version_id")
 
 
 def test_ls(s3):
@@ -548,7 +552,7 @@ def test_rm(s3):
     assert not s3.exists(a)
     # the API is OK with deleting non-files; maybe this is an effect of using bulk
     with pytest.raises(FileNotFoundError):
-        s3.rm(test_bucket_name + '/nonexistent')
+        s3.rm(test_bucket_name + "/nonexistent")
 
     with pytest.raises(FileNotFoundError):
         s3.rm("nonexistent")
@@ -609,42 +613,38 @@ def test_bulk_delete(s3):
     s3.rm(test_bucket_name, recursive=True)
 
     # delete multiple files and directory
-    s3.mkdir('test/dir1')
+    s3.mkdir("test/dir1")
 
-    s3.touch('test/dir1/a.txt')
-    s3.touch('test/dir1/b.txt')
-    s3.touch('test/dir1/c.txt')
+    s3.touch("test/dir1/a.txt")
+    s3.touch("test/dir1/b.txt")
+    s3.touch("test/dir1/c.txt")
 
-    s3.touch('test/dir2/a.txt')
-    s3.touch('test/dir2/b.txt')
-    s3.touch('test/dir2/c.txt')
+    s3.touch("test/dir2/a.txt")
+    s3.touch("test/dir2/b.txt")
+    s3.touch("test/dir2/c.txt")
 
-    s3.mkdir('test/dir2/dir3')
+    s3.mkdir("test/dir2/dir3")
 
-    s3.makedirs('test/dir5/dir6')
+    s3.makedirs("test/dir5/dir6")
 
-    s3.makedirs('test2/dir7')
+    s3.makedirs("test2/dir7")
 
     # new bucket
-    s3.touch('test2/dir7/something')
+    s3.touch("test2/dir7/something")
 
     # multi-bucket bulk delete
-    s3.rm([
-        'test/dir2/a.txt',
-        'test/dir2/dir3',
-        'test2/dir7/something'
-    ])
-    assert s3.exists('test2')
+    s3.rm(["test/dir2/a.txt", "test/dir2/dir3", "test2/dir7/something"])
+    assert s3.exists("test2")
 
-    assert len(s3.ls('test/dir2')) == 2
+    assert len(s3.ls("test/dir2")) == 2
 
-    s3.rm('test/dir1', recursive=True)
-    assert not s3.exists('test/dir1')
-    assert len(s3.ls('test')) == 2
-    assert len(s3.ls('test/dir2')) == 2
+    s3.rm("test/dir1", recursive=True)
+    assert not s3.exists("test/dir1")
+    assert len(s3.ls("test")) == 2
+    assert len(s3.ls("test/dir2")) == 2
 
-    s3.rm('test', recursive=True)
-    assert not s3.exists('test')
+    s3.rm("test", recursive=True)
+    assert not s3.exists("test")
 
 
 @pytest.mark.xfail(reason="anon user is still priviliged on moto")
@@ -1808,7 +1808,7 @@ def test_via_fsspec(s3):
     # TODO: should this test not connecting to S3?
     #  replace fs.rm with s3.rm
     # Interim: removing the residual local folder `mine`
-    fs = fsspec.filesystem('file')
+    fs = fsspec.filesystem("file")
     fs.rm("mine", recursive=True)
 
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -1805,6 +1805,12 @@ def test_via_fsspec(s3):
     with fsspec.open("mine/oi", "rb") as f:
         assert f.read() == b"hello"
 
+    # TODO: should this test not connecting to S3?
+    #  replace fs.rm with s3.rm
+    # Interim: removing the residual local folder `mine`
+    fs = fsspec.filesystem('file')
+    fs.rm("mine", recursive=True)
+
 
 def test_repeat_exists(s3):
     fn = "s3://" + test_bucket_name + "/file1"

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -411,6 +411,26 @@ def test_not_delegate():
     assert out == {"anon": False}
 
 
+def test_split_path(s3):
+    assert s3.split_path(
+        "s3://mybucket/path/to/directory/"
+    ) == ('mybucket', 'path/to/directory', None)
+
+    assert s3.split_path(
+        "s3://mybucket/path/to/file"
+    ) == ('mybucket', 'path/to/file', None)
+
+    assert s3.split_path(
+        "s3://mybucket/path/to/versioned_file?versionId=some_version_id"
+    ) == ('mybucket', 'path/to/versioned_file', None)
+
+    s3.version_aware = True
+
+    assert s3.split_path(
+        "s3://mybucket/path/to/versioned_file?versionId=some_version_id"
+    ) == ('mybucket', 'path/to/versioned_file', 'some_version_id')
+
+
 def test_ls(s3):
     assert set(s3.ls("")) == {
         test_bucket_name,

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -235,12 +235,10 @@ def test_info(s3):
     assert id(s3.info(a)) == id(s3.dircache[parent][0])  # is object from cache
 
     new_parent = test_bucket_name + "/foo"
-    s3.mkdir(new_parent)
-    with pytest.raises(FileNotFoundError):
-        s3.info(new_parent)
+    s3.makedirs(new_parent)
+    assert s3.isdir(new_parent)
+    assert not s3.isfile(new_parent)
     s3.ls(new_parent)
-    with pytest.raises(FileNotFoundError):
-        s3.info(new_parent)
 
 
 def test_info_cached(s3):
@@ -575,6 +573,8 @@ def test_makedirs(s3):
     bucket = "test_makedirs_bucket"
     test_file = bucket + "/a/b/c/file"
     s3.makedirs(test_file)
+    assert s3.isdir(test_file)
+    assert not s3.isfile(test_file)
     assert bucket in s3.ls("/")
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 mock; python_version < '3.3'
+flask>=1.1.2
 moto>=1.3.7
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
A comprehensive solution for creating a folder on S3 to resolve #401 

AWS has a concept of S3 folders. Check https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-folders.html

> The Amazon S3 console treats all objects that have a forward slash "/" character as the last (trailing) character in the key name as a folder, for example examplekeyname/. You can't upload an object that has a key name with a trailing "/" character using the Amazon S3 console. However, you can upload objects that are named with a trailing "/" with the Amazon S3 API by using the AWS CLI, AWS SDKs, or REST API.

Cleared few TODO's and enriched test cases.