### PR TITLE
pin aiobotocore in requirements?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=1.4.1
+aiobotocore==1.4.1
 fsspec==2021.11.0
 aiohttp>=3.7.1


### PR DESCRIPTION
Related to https://github.com/fsspec/s3fs/issues/528

Correct me if i'm wrong, if you install s3fs using pip today your get aiobotocore 1.4.2 and if install using conda you get aiobotocore 1.4.1? (https://github.com/conda-forge/s3fs-feedstock/blob/master/recipe/meta.yaml#L25)

You can run in the dask MyBinder https://mybinder.org/v2/gh/dask/dask-tutorial/main?urlpath=lab/tree/00_overview.ipynb

```
$ conda create -n sf3fs_pip python=3.9 --y && conda activate sf3fs_pip && pip install s3fs && conda-list
# Name                    Version                   Build  Channel
aiobotocore               1.4.2                    pypi_0    pypi
```

```
$ conda deactivate
```

```
$ conda create -n sf3fs_conda python=3.9 --y && conda activate sf3fs_conda && conda install -c conda-forge s3fs --y && conda-list
# Name                    Version                   Build  Channel
aiobotocore               1.4.1              pyhd8ed1ab_0    conda-forge
```