### PR TITLE
bump aiobotocore to 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba env update -f requirements-dev.yml
+          pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda info
           conda list
           conda --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,14 @@ jobs:
           auto-update-conda: true
           channels: conda-forge
           mamba-version: '*'
-          activate-environment: test
+          activate-environment: s3fs-dev
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         shell: bash -l {0}
         run: |
           mamba env update -f requirements-dev.yml
+          conda info
           conda list
           conda --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,15 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          miniconda-version: latest
+          channels: conda-forge
+          mamba-version: '*'
           activate-environment: test
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge pip botocore aiobotocore "moto>=2.0" pytest flake8 black -y
+          mamba env update -f requirements-dev.yml
           pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda list
           conda --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba env update -f requirements-dev.yml
-          pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda info
           conda list
           conda --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,8 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba env update -f requirements-dev.yml
-          pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda list
           conda --version
-
-      - name: Install
-        shell: bash -l {0}
-        run: python setup.py install
 
       - name: Run Tests
         shell: bash -l {0}

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -7,8 +7,11 @@ dependencies:
   - aiobotocore==1.4.2
   - aiohttp>=3.7.1
   - black
-  - pytest>=4.2.0
-  - pytest-env
   - flake8
   - fsspec==2021.11.0
   - moto>=2.0.0
+  - pip
+  - pytest>=4.2.0
+  - pytest-env
+  - pip:
+      - -e .

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -13,5 +13,3 @@ dependencies:
   - pip
   - pytest>=4.2.0
   - pytest-env
-  - pip:
-      - -e .

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -1,0 +1,14 @@
+name: s3fs-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.9
+  - aiobotocore==1.4.2
+  - aiohttp>=3.7.1
+  - black
+  - pytest>=4.2.0
+  - pytest-env
+  - flake8
+  - fsspec==2021.11.0
+  - moto>=2.0.0

--- a/requirements-dev.yml
+++ b/requirements-dev.yml
@@ -8,8 +8,9 @@ dependencies:
   - aiohttp>=3.7.1
   - black
   - flake8
-  - fsspec==2021.11.0
   - moto>=2.0.0
   - pip
   - pytest>=4.2.0
   - pytest-env
+  - pip:
+      - git+https://github.com/fsspec/filesystem_spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=1.4.1
+aiobotocore==1.4.2
 fsspec==2021.11.0
 aiohttp>=3.7.1


### PR DESCRIPTION
bumped aiobotocore to 1.4.2 and updated the ci to point to a yml file (with aiobotocore==1.4.2).

In discovery of https://github.com/fsspec/s3fs/pull/553 when working on a VM I got a `botocore.exceptions.NoCredentialsError: Unable to locate credentials` when I installed s3fs using conda. The tail of the Trackback looks like:

```
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/fsspec/asyn.py", line 91, in wrapper
    return sync(self.loop, func, *args, **kwargs)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/fsspec/asyn.py", line 71, in sync
    raise return_result
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/fsspec/asyn.py", line 25, in _runner
    result[0] = await coro
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/s3fs/core.py", line 1128, in _isdir
    return bool(await self._lsdir(path))
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/s3fs/core.py", line 580, in _lsdir
    async for i in it:
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/paginate.py", line 32, in __anext__
    response = await self._make_request(current_kwargs)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/client.py", line 141, in _make_api_call
    http, parsed_response = await self._make_request(
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/client.py", line 161, in _make_request
    return await self._endpoint.make_request(operation_model, request_dict)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/endpoint.py", line 77, in _send_request
    request = await self.create_request(request_dict, operation_model)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/endpoint.py", line 70, in create_request
    await self._event_emitter.emit(event_name, request=request,
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/hooks.py", line 27, in _emit
    response = await handler(**kwargs)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/signers.py", line 16, in handler
    return await self.sign(operation_name, request)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/aiobotocore/signers.py", line 63, in sign
    auth.add_auth(request)
  File "/opt/userenvs/ray.bell/test_env2/lib/python3.9/site-packages/botocore/auth.py", line 373, in add_auth
    raise NoCredentialsError()
```

However, when installing from pip which grabbed aiobotocore 1.4.2 I was able to do `pd.read_parquet("s3://bucket/file.parquet")`. This solves my use case and I hope doesn't break anything for others. 