### PR TITLE
simple pin of aiobotocore in requirements.txt and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge pip botocore aiobotocore "moto>=2.0" pytest flake8 black -y
+          conda install -c conda-forge pip botocore aiobotocore==1.4.2 "moto>=2.0" pytest flake8 black -y
           pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda list
           conda --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=1.4.1
+aiobotocore==1.4.2
 fsspec==2021.11.0
 aiohttp>=3.7.1


### PR DESCRIPTION
Motivation of PR here: https://github.com/fsspec/s3fs/pull/554#issue-782315055

This picks up aiobotocore==1.4.2 in the CI: https://github.com/fsspec/s3fs/runs/4240157139?check_suite_focus=true#step:4:527

Currently CI grabs aiobotocore==1.4.1 e.g. https://github.com/fsspec/s3fs/runs/4228322835?check_suite_focus=true#step:4:37 which is from #552 