### PR TITLE
bump aiobotocore to 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge pip botocore aiobotocore==2.0.1 "aiohttp<=4" "moto>=2.0" pytest flake8 black -y
+          conda install -c conda-forge pip botocore aiobotocore==2.1.0 "aiohttp<=4" "moto>=2.0" pytest flake8 black -y
           pip install git+https://github.com/fsspec/filesystem_spec --no-deps
           conda list
           conda --version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=2.0.1
+aiobotocore~=2.1.0
 fsspec==2021.11.1
 aiohttp<=4


### PR DESCRIPTION
aiobotocore is one of the dependencies of s3fs.

I have updated aiobotocore from 2.0.1 to the latest 2.1.0.

[Background]
boto is used by many different libraries, so it is difficult to lock the boto version.
When I use botocore 1.23.0 or later, I face and opened this issue https://github.com/aio-libs/aiobotocore/issues/905

And this issue has been resolved by this PR https://github.com/aio-libs/aiobotocore/pull/909
Updated version was released with aiobotocore 2.1.0 So I want to use this version from s3fs.

I'll show the log after applying my PR.

Before

```
>>> import s3fs
>>> fs = s3fs.S3FileSystem()
>>> fs.ls('hayshogo-s3')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/fsspec/asyn.py", line 91, in wrapper
    return sync(self.loop, func, *args, **kwargs)
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/fsspec/asyn.py", line 71, in sync
    raise return_result
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/fsspec/asyn.py", line 25, in _runner
    result[0] = await coro
  File "/Users/hayshogo/repositories/thirdparty/s3fs/s3fs/core.py", line 810, in _ls
    files = await self._lsdir(path, refresh)
  File "/Users/hayshogo/repositories/thirdparty/s3fs/s3fs/core.py", line 578, in _lsdir
    await self.set_session()
  File "/Users/hayshogo/repositories/thirdparty/s3fs/s3fs/core.py", line 420, in set_session
    self._s3 = await s3creator.__aenter__()
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/aiobotocore/session.py", line 37, in __aenter__
    self._client = await self._coro
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/aiobotocore/session.py", line 121, in _create_client
    client = await client_creator.create_client(
  File "/Users/hayshogo/.local/lib/python3.9/site-packages/aiobotocore/client.py", line 45, in create_client
    self._register_lazy_block_unknown_fips_pseudo_regions(service_client)
AttributeError: 'AioClientCreator' object has no attribute '_register_lazy_block_unknown_fips_pseudo_regions'
```


After

```
>>> import s3fs
>>> fs = s3fs.S3FileSystem()
>>> fs.ls('hayshogo-s3')
['hayshogo-s3/dist', 'hayshogo-s3/sample.txt', 'hayshogo-s3/src']
```

Thank you,