### PR TITLE
Set content type on upload

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -945,10 +945,10 @@ class S3FileSystem(AsyncFileSystem):
                 await self._mkdir(lpath)
         size = os.path.getsize(lpath)
 
-        content_type, _ = mimetypes.guess_type(lpath)
-
-        if content_type is not None:
-            kwargs.setdefault("ContentType", content_type)
+        if "ContentType" not in kwargs:
+            content_type, _ = mimetypes.guess_type(lpath)
+            if content_type is not None:
+                kwargs["ContentType"] = content_type
 
         with open(lpath, "rb") as f0:
             if size < min(5 * 2 ** 30, 2 * chunksize):

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -945,8 +945,10 @@ class S3FileSystem(AsyncFileSystem):
                 await self._mkdir(lpath)
         size = os.path.getsize(lpath)
 
-        content_type = mimetypes.guess_type(lpath)
-        kwargs.update({"ContentType": content_type[0]})
+        content_type, _ = mimetypes.guess_type(lpath)
+
+        if content_type is not None:
+            kwargs.setdefault("ContentType", content_type)
 
         with open(lpath, "rb") as f0:
             if size < min(5 * 2 ** 30, 2 * chunksize):

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -694,6 +694,7 @@ def test_s3_file_info(s3):
     with pytest.raises(FileNotFoundError):
         s3.info(fn + "another")
 
+
 def test_content_type_is_set(s3, tmpdir):
     test_file = str(tmpdir) + "/test.json"
     destination = test_bucket_name + "/test.json"
@@ -701,12 +702,14 @@ def test_content_type_is_set(s3, tmpdir):
     s3.put(test_file, destination)
     assert s3.info(destination)["ContentType"] == "application/json"
 
+
 def test_content_type_is_not_overrided(s3, tmpdir):
     test_file = os.path.join(str(tmpdir), "test.json")
     destination = os.path.join(test_bucket_name, "test.json")
     open(test_file, "w").write("text")
     s3.put(test_file, destination, ContentType="text/css")
     assert s3.info(destination)["ContentType"] == "text/css"
+
 
 def test_bucket_exists(s3):
     assert s3.exists(test_bucket_name)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -695,8 +695,8 @@ def test_s3_file_info(s3):
         s3.info(fn + "another")
 
 def test_content_type_is_set(s3, tmpdir):
-    test_file = os.path.join(str(tmpdir), "test.json")
-    destination = os.path.join(test_bucket_name, "test.json")
+    test_file = str(tmpdir) + "/test.json"
+    destination = test_bucket_name + "/test.json"
     open(test_file, "w").write("text")
     s3.put(test_file, destination)
     assert s3.info(destination)["ContentType"] == "application/json"

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -699,7 +699,7 @@ def test_content_type_is_set(s3, tmpdir):
     destination = os.path.join(test_bucket_name, "test.json")
     open(test_file, "w").write("text")
     s3.put(test_file, destination)
-    assert s3.info(destination)["ContentType"] == "text/json"
+    assert s3.info(destination)["ContentType"] == "application/json"
 
 def test_content_type_is_not_overrided(s3, tmpdir):
     test_file = os.path.join(str(tmpdir), "test.json")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -694,6 +694,19 @@ def test_s3_file_info(s3):
     with pytest.raises(FileNotFoundError):
         s3.info(fn + "another")
 
+def test_content_type_is_set(s3, tmpdir):
+    test_file = os.path.join(str(tmpdir), "test.json")
+    destination = os.path.join(test_bucket_name, "test.json")
+    open(test_file, "w").write("text")
+    s3.put(test_file, destination)
+    assert s3.info(destination)["ContentType"] == "text/json"
+
+def test_content_type_is_not_overrided(s3, tmpdir):
+    test_file = os.path.join(str(tmpdir), "test.json")
+    destination = os.path.join(test_bucket_name, "test.json")
+    open(test_file, "w").write("text")
+    s3.put(test_file, destination, ContentType="text/css")
+    assert s3.info(destination)["ContentType"] == "text/css"
 
 def test_bucket_exists(s3):
     assert s3.exists(test_bucket_name)


### PR DESCRIPTION
This PR adds the content type to uploaded objects by populating the "ContentType" kwarg using mimetypes. I'm not sure how to test this and also unsure about if anything extra is needed for multipart, would love clarity on that.

tested with 

```
pytest s3fs/tests/test_s3fs.py -k test_content_type
```