### PR TITLE
add development page to docs

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -3,8 +3,7 @@ Development
 
 Create a development environment::
 
-    $ pip install -r requirements.txt
-    $ pip install -r test_requirements.txt
+    $ pip install -r requirements.txt -r test_requirements.txt
 
 Run tests::
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,11 @@
+Development
+===========
+
+Create a development environment::
+
+    $ pip install -r requirements.txt
+    $ pip install -r test_requirements.txt
+
+Run tests::
+
+    $ pytest


### PR DESCRIPTION
I'm would like to add this page as I have to recently (re)think about create a development environment and running tests.

My goal is this would be copy-pastable to help new contributors.

I imagine this could be expanded in the future e.g. https://docs.dask.org/en/stable/develop.html#install 