### PR TITLE
tests: limit moto <3

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 mock; python_version < '3.3'
-moto>=2.0.0
+moto>=2,<3
 flask
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
moto recently released version 3, that broke our CI https://github.com/fsspec/filesystem_spec/runs/5139980542?check_suite_focus=true

Looks like moto 3 could be swallowing some headers, so playing it safe with 2.0 for now.