### PR TITLE
Add retries to _cat_file and _get_file. Closes #537

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -244,7 +244,7 @@ class S3FileSystem(AsyncFileSystem):
         cache_regions=False,
         asynchronous=False,
         loop=None,
-        **kwargs
+        **kwargs,
     ):
         if key and username:
             raise KeyError("Supply either key or username, not both")
@@ -522,7 +522,7 @@ class S3FileSystem(AsyncFileSystem):
         autocommit=True,
         requester_pays=None,
         cache_options=None,
-        **kwargs
+        **kwargs,
     ):
         """Open a file for reading or writing
 
@@ -1041,7 +1041,7 @@ class S3FileSystem(AsyncFileSystem):
                 "get_object",
                 Bucket=bucket,
                 Key=key,
-                Range=f'bytes={range}-',
+                Range=f"bytes={range}-",
                 **version_id_kw(version_id or vers),
                 **self.req_kw,
             )
@@ -1069,7 +1069,7 @@ class S3FileSystem(AsyncFileSystem):
                         except Exception:
                             pass
 
-                        await asyncio.sleep(min(1.7 ** failed_reads * 0.1, 15))
+                        await asyncio.sleep(min(1.7**failed_reads * 0.1, 15))
                         # Byte ranges are inclusive, which means we need to be careful to not read the same data twice
                         # in a failure.
                         # Examples:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1047,7 +1047,7 @@ class S3FileSystem(AsyncFileSystem):
             )
             return resp["Body"], resp.get("ContentLength", None)
 
-        body, content_length = _open_file(range=0)
+        body, content_length = await _open_file(range=0)
         callback.set_size(content_length)
 
         failed_reads = 0
@@ -1077,7 +1077,7 @@ class S3FileSystem(AsyncFileSystem):
                         # Read 1 byte, success. Read 1 byte: failure. Retry with read_range=2, byte-range should be 2-
                         # Read 1 bytes, success. Read 1 bytes: success. Read 1 byte, failure. Retry with read_range=3,
                         # byte-range should be 3-.
-                        body, _ = _open_file(bytes_read + 1)
+                        body, _ = await _open_file(bytes_read + 1)
                         continue
 
                     if not chunk:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1037,11 +1037,13 @@ class S3FileSystem(AsyncFileSystem):
         bucket, key, vers = self.split_path(rpath)
 
         async def _open_file(range: int):
+            kw = self.req_kw.copy()
+            if range:
+                kw["Range"] = f"bytes={range}-"
             resp = await self._call_s3(
                 "get_object",
                 Bucket=bucket,
                 Key=key,
-                Range=f"bytes={range}-",
                 **version_id_kw(version_id or vers),
                 **self.req_kw,
             )

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1041,7 +1041,7 @@ class S3FileSystem(AsyncFileSystem):
                 "get_object",
                 Bucket=bucket,
                 Key=key,
-                Range=f'{range}-',
+                Range=f'bytes={range}-',
                 **version_id_kw(version_id or vers),
                 **self.req_kw,
             )


### PR DESCRIPTION
I'd really like to use backoff for this (https://pypi.org/project/backoff/), but for now this seems like a good simple implementation that is compatible with the existing implementation.

I added `FSTimeoutError` to the list of retryable errors as I've seen this also pop up when S3 is under load.