### PR TITLE
Allow empty etag in _info.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1071,7 +1071,7 @@ class S3FileSystem(AsyncFileSystem):
                     **self.req_kw,
                 )
                 return {
-                    "ETag": out["ETag"],
+                    "ETag": out.get("ETag", ""),
                     "LastModified": out["LastModified"],
                     "size": out["ContentLength"],
                     "name": "/".join([bucket, key]),


### PR DESCRIPTION
Similar to this pull request: https://github.com/fsspec/s3fs/pull/480 .

We encounter problems when accessing files hosted by Minio which might not be uploaded through Minio API (e.g., Minio on HDFS gateway, local files). This simple fix could solve problems like: https://github.com/iterative/dvc/issues/7161 .