### PR TITLE
Add recursive rm test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         exclude: ^docs/

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2274,6 +2274,19 @@ def test_lsdir(s3):
     assert d in s3.ls(test_bucket_name)
 
 
+def test_rm_recursive_folder(s3):
+    s3.touch(test_bucket_name + "/sub/file")
+    s3.rm(test_bucket_name + "/sub", recursive=True)
+    assert not s3.exists(test_bucket_name + "/sub/file")
+    assert not s3.exists(test_bucket_name + "/sub")
+
+    s3.touch(test_bucket_name + "/sub/file")
+    s3.rm(test_bucket_name, recursive=True)
+    assert not s3.exists(test_bucket_name + "/sub/file")
+    assert not s3.exists(test_bucket_name + "/sub")
+    assert not s3.exists(test_bucket_name)
+
+
 def test_copy_file_without_etag(s3, monkeypatch):
 
     s3.touch(test_bucket_name + "/copy_tests/file")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2281,7 +2281,7 @@ def test_rm_recursive_folder(s3):
     assert not s3.exists(test_bucket_name + "/sub")
 
     s3.touch(test_bucket_name + "/sub/file")
-    s3.touch(test_bucket_name + "/sub/") # placeholder
+    s3.touch(test_bucket_name + "/sub/")  # placeholder
     s3.rm(test_bucket_name + "/sub", recursive=True)
     assert not s3.exists(test_bucket_name + "/sub/file")
     assert not s3.exists(test_bucket_name + "/sub")
@@ -2291,6 +2291,7 @@ def test_rm_recursive_folder(s3):
     assert not s3.exists(test_bucket_name + "/sub/file")
     assert not s3.exists(test_bucket_name + "/sub")
     assert not s3.exists(test_bucket_name)
+
 
 def test_copy_file_without_etag(s3, monkeypatch):
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2281,11 +2281,16 @@ def test_rm_recursive_folder(s3):
     assert not s3.exists(test_bucket_name + "/sub")
 
     s3.touch(test_bucket_name + "/sub/file")
+    s3.touch(test_bucket_name + "/sub/") # placeholder
+    s3.rm(test_bucket_name + "/sub", recursive=True)
+    assert not s3.exists(test_bucket_name + "/sub/file")
+    assert not s3.exists(test_bucket_name + "/sub")
+
+    s3.touch(test_bucket_name + "/sub/file")
     s3.rm(test_bucket_name, recursive=True)
     assert not s3.exists(test_bucket_name + "/sub/file")
     assert not s3.exists(test_bucket_name + "/sub")
     assert not s3.exists(test_bucket_name)
-
 
 def test_copy_file_without_etag(s3, monkeypatch):
 


### PR DESCRIPTION
Closes #317

@sweco - the test seems to show that the functionality is working as expected. If in your case, you *also* have an empty key directory placeholder key, then I this it is reasonable that it isn't automatically deleted, and you should need to issue `rm` on the key again (because they key is not contained within the directory). 