### PR TITLE
Throttle bulk deletes to ~3000 keys per second

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1670,7 +1670,6 @@ class S3FileSystem(AsyncFileSystem):
             subset = files[i : i + self.concurrent_batched_deletes]
             # don't bother sleeping for the last batch
             slow_down = 1 if i + self.concurrent_batched_deletes < len(files) else 0
-            print(f"Deleting subset {i}, {i+self.concurrent_batched_deletes}")
             await asyncio.gather(
                 *[
                     self._bulk_delete(subset[j : j + 1000])


### PR DESCRIPTION
Possible fix for #484 

I wrote this up not knowing about `asyn._run_coro_in_chunks()`, but I'm not sure if that function can do exactly what I want here.
 In particular, I want each chunk of coroutines to take *at least* a certain amount of time to satisfy [rate limits](https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/). Unfortunately, it seems that the rate limits are per-key rather than per-request (at least, that's my current thinking).