### PR TITLE
Fix syntax error hiding minio code sample

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -194,6 +194,7 @@ creating the ``s3fs`` filesystem. Here are some sample configurations:
 For a self-hosted MinIO instance:
 
 .. code-block:: python
+
    # When relying on auto discovery for credentials
    >>> s3 = s3fs.S3FileSystem(
          anon=False,


### PR DESCRIPTION
Without this, the code sample is just hidden

From https://s3fs.readthedocs.io/en/latest/index.html?highlight=minio#s3-compatible-storage

<img width="882" alt="image" src="https://user-images.githubusercontent.com/30430/182556692-6a19a358-bbaa-4c17-8d15-720b6a43c631.png">


