### PR TITLE
Fix `pip install --pre s3fs`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiobotocore~=2.3.4
 fsspec==2022.7.1
-aiohttp
+aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
It is not possible to run `pip install --pre s3fs` right now because the two latest pre-releases of `aiohttp` are broken (v4.0.0a0 and v4.0.0a1).

This PR proposes excluding these two versions from the s3fs requirements.

More details: https://github.com/fsspec/filesystem_spec/pull/1018