### PR TITLE
Allow use of `s3fs` when `fsspec` is mediated by a `LazyLoader`

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -11,6 +11,7 @@ import re
 
 from urllib3.exceptions import IncompleteRead
 
+import fsspec  # noqa: F401
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_storage_options, tokenize, setup_logging as setup_logger
 from fsspec.asyn import (


### PR DESCRIPTION
Hi all, greetings from Polars... 

We had an issue (https://github.com/pola-rs/polars/issues/5451) raised just now, relating to #662 here. I've started debugging this on our side; we make use of `importlib`'s [LazyLoader](https://docs.python.org/3/library/importlib.html#importlib.util.LazyLoader) class to defer loading several modules, with `fsspec` being amongst them.
 
I've spotted a one-liner you can add which fixes the issue at (apparently) no cost, and it will guard against similar gremlins if anyone else lazy-loads `fsspec` - just to be clear, I will keep looking for a lower-level solution on our side, as it shouldn't really be on you to handle somebody else lazy-loading  ;)

As you can tell from the simplicity of the patch, the jump straight to submodule imports appears to bypass the standard `LazyLoader` machinery for detecting module usage and properly loading the root (despite the submodules being lazy-loaded successfully!) Most likely connected to some subtlety of [submodule](https://docs.python.org/3/reference/import.html#submodules) binding/references, but we shall see...

Regards.