### PR TITLE
Handle temporary errors in HeadBucket

### DIFF
--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -37,12 +37,18 @@ class S3BucketRegionCache:
 
         try:
             response = await general_client.head_bucket(Bucket=bucket_name)
-        except ClientError:
-            logger.debug(
-                "RC: HEAD_BUCKET call for %r has failed, returning the general client",
-                bucket_name,
+        except ClientError as e:
+            region = (
+                e.response["ResponseMetadata"]
+                .get("HTTPHeaders", {})
+                .get("x-amz-bucket-region")
             )
-            return general_client
+            if not region:
+                logger.debug(
+                    "RC: HEAD_BUCKET call for %r has failed, returning the general client",
+                    bucket_name,
+                )
+                return general_client
         else:
             region = response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"]
 


### PR DESCRIPTION
For freshly created S3 buckets, boto `head_bucket` will fail with `ERR An error occurred (403) when calling the HeadBucket operation: Forbidden` even though ResponseMetadata will contain the correct region header - for up to an hour in my experience.

This PR adds handling for this and continues if the region header is present despite HeadBucket failing.