### PR TITLE
Add Storj DCS as an explicit endpoint for S3-compatible storage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -210,6 +210,26 @@ For a self-hosted MinIO instance:
             'endpoint_url': 'https://...'
          }
       )
+      
+For Storj DCS via the S3-compatible gateway:
+
+.. code-block:: python
+
+   # When relying on auto discovery for credentials
+   >>> s3 = s3fs.S3FileSystem(
+         anon=False,
+         client_kwargs={
+            'endpoint_url': 'https://gateway.storjshare.io'
+         }
+      )
+   # Or passing the credentials directly
+   >>> s3 = s3fs.S3FileSystem(
+         key='miniokey...',
+         secret='asecretkey...',
+         client_kwargs={
+            'endpoint_url': 'https://gateway.storjshare.io'
+         }
+      )
 
 For a Scaleway s3-compatible storage in the ``fr-par`` zone:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -210,7 +210,7 @@ For a self-hosted MinIO instance:
             'endpoint_url': 'https://...'
          }
       )
-      
+
 For Storj DCS via the `S3-compatible Gateway <https://docs.storj.io/dcs/getting-started/quickstart-aws-sdk-and-hosted-gateway-mt>`_:
 
 .. code-block:: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -211,7 +211,7 @@ For a self-hosted MinIO instance:
          }
       )
       
-For Storj DCS via the S3-compatible gateway:
+For Storj DCS via the `S3-compatible Gateway <https://docs.storj.io/dcs/getting-started/quickstart-aws-sdk-and-hosted-gateway-mt>`_:
 
 .. code-block:: python
 
@@ -224,7 +224,7 @@ For Storj DCS via the S3-compatible gateway:
       )
    # Or passing the credentials directly
    >>> s3 = s3fs.S3FileSystem(
-         key='miniokey...',
+         key='accesskey...',
          secret='asecretkey...',
          client_kwargs={
             'endpoint_url': 'https://gateway.storjshare.io'


### PR DESCRIPTION
This PR simply updates the documentation to add Storj DCS (https://github.com/storj/storj) as an explicit S3-compatible (supported) method for S3Fs.

Storj DCS is a distributed and open-source cloud storage network that is becoming popular for Hugging Face developers for Datasets – due to it's global availability coupled with an empirically better security and economic model.  

Thanks – and also excited to add S3Fs as a reference within the Storj docs as a "how-to" after merge, as reciprocity!