### PR TITLE
Update docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: miniconda3-4.7
+
+conda:
+  environment: docs/environment.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,9 @@
+name: s3fs
+channels:
+  - defaults
+dependencies:
+  - python= 3.9
+  - botocore
+  - docutils<0.18
+  - numpydoc
+  - sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-numpydoc
-botocore
-sphinx
-sphinx-rtd-theme
-docutils<0.18

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -113,20 +112,13 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 
 extlinks = {
-    "pr": ("https://github.com/fsspec/s3fs/pull/%s", "PR #"),
+    "pr": ("https://github.com/fsspec/s3fs/pull/%s", "PR #%s"),
 }
 
 
 # -- Options for HTML output ----------------------------------------------
 
-# Taken from docs.readthedocs.io:
-# on_rtd is whether we are on readthedocs.io
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This is a WIP to update the docs build to use a Read the Docs v2 config file. I was originally intending just to fix issue #693 but it turns out that RTD is building on Python 3.7 for which quite a few of the dependencies are a bit old and no longer updated. So this is updating the docs build system to follow a similar approach to `fsspec` and to fix a variety of doc-related issues at the same time.