### PR TITLE
add fsid implementation

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1929,6 +1929,12 @@ class S3FileSystem(AsyncFileSystem):
 
     invalidate_region_cache = sync_wrapper(_invalidate_region_cache)
 
+    def fsid(self):
+        """Persistent filesystem id that can be used to compare filesystems
+        across sessions.
+        """
+        return "s3"
+
 
 class S3File(AbstractBufferedFile):
     """

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1929,6 +1929,7 @@ class S3FileSystem(AsyncFileSystem):
 
     invalidate_region_cache = sync_wrapper(_invalidate_region_cache)
 
+    @property
     def fsid(self):
         """Persistent filesystem id that can be used to compare filesystems
         across sessions.

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2574,3 +2574,7 @@ def test_cp_two_files(s3):
         target + "/file0",
         target + "/file1",
     ]
+
+
+def test_fsid(s3):
+    assert s3.fsid == "s3"


### PR DESCRIPTION
Fixes issue #699
As of the latest fsspec release (2023.1.0) a new abstract property was added to the AbstractFileSystem base class.
s3fs should implement this property to prevent problems for users. 