### PR TITLE
Set minimum python to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license="BSD",
     keywords="s3, boto",
     packages=["s3fs"],
-    python_requires=">= 3.7",
+    python_requires=">= 3.8",
     install_requires=[open("requirements.txt").read().strip().split("\n")],
     extras_require={
         "awscli": [f"aiobotocore[awscli]{aiobotocore_version_suffix}"],


### PR DESCRIPTION
Change minimum python version from 3.7 to 3.8, in line with fsspec/filesystem_spec#1184 and  fsspec/filesystem_spec#1185. It was already correct in the classifiers.