### PR TITLE
Enable providing `endpoint_url` through environment variables

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -198,18 +198,25 @@ For a self-hosted MinIO instance:
    # When relying on auto discovery for credentials
    >>> s3 = s3fs.S3FileSystem(
          anon=False,
-         client_kwargs={
-            'endpoint_url': 'https://...'
-         }
+         endpoint_url='https://...'
       )
    # Or passing the credentials directly
    >>> s3 = s3fs.S3FileSystem(
          key='miniokey...',
          secret='asecretkey...',
-         client_kwargs={
-            'endpoint_url': 'https://...'
-         }
+         endpoint_url='https://...'
       )
+
+It is also possible to set credentials through envrironment variables:
+
+.. code-block:: python
+   # export FSSPEC_S3_ENDPOINT_URL=https://...
+   # export FSSPEC_S3_KEY='miniokey...'
+   # export FSSPEC_S3_SECRET='asecretkey...'
+   >>> s3 = s3fs.S3FileSystem()
+   # or ...
+   >>> f = fsspec.open("s3://minio-bucket/...")
+
 
 For Storj DCS via the `S3-compatible Gateway <https://docs.storj.io/dcs/getting-started/quickstart-aws-sdk-and-hosted-gateway-mt>`_:
 
@@ -218,17 +225,13 @@ For Storj DCS via the `S3-compatible Gateway <https://docs.storj.io/dcs/getting-
    # When relying on auto discovery for credentials
    >>> s3 = s3fs.S3FileSystem(
          anon=False,
-         client_kwargs={
-            'endpoint_url': 'https://gateway.storjshare.io'
-         }
+         endpoint_url='https://gateway.storjshare.io'
       )
    # Or passing the credentials directly
    >>> s3 = s3fs.S3FileSystem(
          key='accesskey...',
          secret='asecretkey...',
-         client_kwargs={
-            'endpoint_url': 'https://gateway.storjshare.io'
-         }
+         endpoint_url='https://gateway.storjshare.io'
       )
 
 For a Scaleway s3-compatible storage in the ``fr-par`` zone:
@@ -238,8 +241,8 @@ For a Scaleway s3-compatible storage in the ``fr-par`` zone:
    >>> s3 = s3fs.S3FileSystem(
       key='scaleway-api-key...',
       secret='scaleway-secretkey...',
+      endpoint_url='https://s3.fr-par.scw.cloud',
       client_kwargs={
-         'endpoint_url': 'https://s3.fr-par.scw.cloud',
          'region_name': 'fr-par'
       }
    )
@@ -251,8 +254,8 @@ For an OVH s3-compatible storage in the ``GRA`` zone:
    >>> s3 = s3fs.S3FileSystem(
       key='ovh-s3-key...',
       secret='ovh-s3-secretkey...',
+      endpoint_url='https://s3.GRA.cloud.ovh.net',
       client_kwargs={
-         'endpoint_url': 'https://s3.GRA.cloud.ovh.net',
          'region_name': 'GRA'
       },
       config_kwargs={

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -188,10 +188,10 @@ class S3FileSystem(AsyncFileSystem):
         Use this endpoint_url, if specified. Needed for connecting to non-AWS
         S3 buckets. Takes precedence over `endpoint_url` in client_kwargs.
     key : string (None)
-        If not anonymous, use this access key ID, if specified. Takes precedence 
+        If not anonymous, use this access key ID, if specified. Takes precedence
         over `aws_access_key_id` in client_kwargs.
     secret : string (None)
-        If not anonymous, use this secret access key, if specified. Takes 
+        If not anonymous, use this secret access key, if specified. Takes
         precedence over `aws_secret_access_key` in client_kwargs.
     token : string (None)
         If not anonymous, use this security token, if specified
@@ -291,7 +291,7 @@ class S3FileSystem(AsyncFileSystem):
             key = username
         if password:
             secret = password
-        
+
         self.endpoint_url = endpoint_url
 
         self.anon = anon

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -485,7 +485,6 @@ class S3FileSystem(AsyncFileSystem):
                 "aws_access_key_id",
                 "aws_secret_access_key",
                 "aws_session_token",
-                "endpoint_url",
             }
             init_kwargs = {
                 key: value for key, value in init_kwargs.items() if key not in drop_keys

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -257,6 +257,7 @@ class S3FileSystem(AsyncFileSystem):
     def __init__(
         self,
         anon=False,
+        endpoint_url=None,
         key=None,
         secret=None,
         token=None,
@@ -285,6 +286,8 @@ class S3FileSystem(AsyncFileSystem):
             key = username
         if password:
             secret = password
+        
+        self.endpoint_url = endpoint_url
 
         self.anon = anon
         self.key = key
@@ -460,6 +463,7 @@ class S3FileSystem(AsyncFileSystem):
             aws_access_key_id=self.key,
             aws_secret_access_key=self.secret,
             aws_session_token=self.token,
+            endpoint_url=self.endpoint_url,
         )
         init_kwargs = {
             key: value
@@ -476,6 +480,7 @@ class S3FileSystem(AsyncFileSystem):
                 "aws_access_key_id",
                 "aws_secret_access_key",
                 "aws_session_token",
+                "endpoint_url",
             }
             init_kwargs = {
                 key: value for key, value in init_kwargs.items() if key not in drop_keys

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -184,10 +184,15 @@ class S3FileSystem(AsyncFileSystem):
         Whether to use anonymous connection (public buckets only). If False,
         uses the key/secret given, or boto's credential resolver (client_kwargs,
         environment, variables, config files, EC2 IAM server, in that order)
+    endpoint_url : string (None)
+        Use this endpoint_url, if specified. Needed for connecting to non-AWS
+        S3 buckets. Takes precedence over `endpoint_url` in client_kwargs.
     key : string (None)
-        If not anonymous, use this access key ID, if specified
+        If not anonymous, use this access key ID, if specified. Takes precedence 
+        over `aws_access_key_id` in client_kwargs.
     secret : string (None)
-        If not anonymous, use this secret access key, if specified
+        If not anonymous, use this secret access key, if specified. Takes 
+        precedence over `aws_secret_access_key` in client_kwargs.
     token : string (None)
         If not anonymous, use this security token, if specified
     use_ssl : bool (True)


### PR DESCRIPTION
Currently, if you're using non-AWS S3 endpoint you're stuck with less ergonomic syntax, see https://github.com/fsspec/s3fs/issues/120#issuecomment-647117380 for example.

Sometimes it's feasible, but sometimes it breaks flexibility that `fsspec` provides.

This simple PR makes `endpoint_url` a first-class configuration option, alongside with `key` and `secret`, which are already supported exactly in the same way.