### PR TITLE
bump aiobotocore to 2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=2.4.2
+aiobotocore~=2.5.0
 fsspec==2023.3.0
 aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
Bumps aiobotocore to 2.5.0 to resolve a dependency conflict I'm seeing with a package that depends on the latest boto3.