### PR TITLE
Test using new abstract test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
       - name: Install
         shell: bash -l {0}
         run: |
-          # Temporary fix so that fsspec.tests is available.
-          pip install -ve git+https://github.com/fsspec/filesystem_spec#egg=fsspec
-          #pip install git+https://github.com/fsspec/filesystem_spec
+          pip install git+https://github.com/fsspec/filesystem_spec
           pip install . --no-deps
 
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Install
         shell: bash -l {0}
         run: |
-          pip install git+https://github.com/fsspec/filesystem_spec
+          # Temporary fix so that fsspec.tests is available.
+          pip install -ve git+https://github.com/fsspec/filesystem_spec#egg=fsspec
+          #pip install git+https://github.com/fsspec/filesystem_spec
           pip install . --no-deps
 
       - name: Run Tests

--- a/s3fs/tests/derived/s3fs_fixtures.py
+++ b/s3fs/tests/derived/s3fs_fixtures.py
@@ -63,6 +63,9 @@ class S3fsFixtures(AbstractFixtures):
     def fs_path():
         return test_bucket_name
 
+    def supports_empty_directories(self):
+        return False
+
     @staticmethod
     @pytest.fixture
     def _get_boto3_client():

--- a/s3fs/tests/derived/s3fs_fixtures.py
+++ b/s3fs/tests/derived/s3fs_fixtures.py
@@ -16,9 +16,9 @@ endpoint_uri = "http://127.0.0.1:%s/" % port
 
 
 class S3fsFixtures(AbstractFixtures):
-    @staticmethod
-    @pytest.fixture
-    def fs(_s3_base, _get_boto3_client):
+    @pytest.fixture(scope="class")
+    def fs(self, _s3_base, _get_boto3_client):
+        print("FS")
         client = _get_boto3_client
         client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
 
@@ -58,26 +58,23 @@ class S3fsFixtures(AbstractFixtures):
         s3.invalidate_cache()
         yield s3
 
-    @staticmethod
     @pytest.fixture
-    def fs_path():
+    def fs_path(self):
         return test_bucket_name
 
     def supports_empty_directories(self):
         return False
 
-    @staticmethod
-    @pytest.fixture
-    def _get_boto3_client():
+    @pytest.fixture(scope="class")
+    def _get_boto3_client(self):
         from botocore.session import Session
 
         # NB: we use the sync botocore client for setup
         session = Session()
         return session.create_client("s3", endpoint_url=endpoint_uri)
 
-    @staticmethod
-    @pytest.fixture
-    def _s3_base():
+    @pytest.fixture(scope="class")
+    def _s3_base(self):
         # writable local S3 system
         import shlex
         import subprocess

--- a/s3fs/tests/derived/s3fs_fixtures.py
+++ b/s3fs/tests/derived/s3fs_fixtures.py
@@ -1,0 +1,116 @@
+import json
+import os
+import pytest
+import requests
+import time
+
+from fsspec.tests.abstract import AbstractFixtures
+from s3fs.core import S3FileSystem
+
+
+test_bucket_name = "test"
+secure_bucket_name = "test-secure"
+versioned_bucket_name = "test-versioned"
+port = 5555
+endpoint_uri = "http://127.0.0.1:%s/" % port
+
+
+class S3fsFixtures(AbstractFixtures):
+    @staticmethod
+    @pytest.fixture
+    def fs(_s3_base, _get_boto3_client):
+        client = _get_boto3_client
+        client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
+
+        client.create_bucket(Bucket=versioned_bucket_name, ACL="public-read")
+        client.put_bucket_versioning(
+            Bucket=versioned_bucket_name, VersioningConfiguration={"Status": "Enabled"}
+        )
+
+        # initialize secure bucket
+        client.create_bucket(Bucket=secure_bucket_name, ACL="public-read")
+        policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Id": "PutObjPolicy",
+                "Statement": [
+                    {
+                        "Sid": "DenyUnEncryptedObjectUploads",
+                        "Effect": "Deny",
+                        "Principal": "*",
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::{bucket_name}/*".format(
+                            bucket_name=secure_bucket_name
+                        ),
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "aws:kms"
+                            }
+                        },
+                    }
+                ],
+            }
+        )
+        client.put_bucket_policy(Bucket=secure_bucket_name, Policy=policy)
+
+        S3FileSystem.clear_instance_cache()
+        s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri})
+        s3.invalidate_cache()
+        yield s3
+
+    @staticmethod
+    @pytest.fixture
+    def fs_path():
+        return test_bucket_name
+
+    @staticmethod
+    @pytest.fixture
+    def _get_boto3_client():
+        from botocore.session import Session
+
+        # NB: we use the sync botocore client for setup
+        session = Session()
+        return session.create_client("s3", endpoint_url=endpoint_uri)
+
+    @staticmethod
+    @pytest.fixture
+    def _s3_base():
+        # writable local S3 system
+        import shlex
+        import subprocess
+
+        try:
+            # should fail since we didn't start server yet
+            r = requests.get(endpoint_uri)
+        except:
+            pass
+        else:
+            if r.ok:
+                raise RuntimeError("moto server already up")
+        if "AWS_SECRET_ACCESS_KEY" not in os.environ:
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "foo"
+        if "AWS_ACCESS_KEY_ID" not in os.environ:
+            os.environ["AWS_ACCESS_KEY_ID"] = "foo"
+        proc = subprocess.Popen(
+            shlex.split("moto_server s3 -p %s" % port),
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+        )
+
+        timeout = 5
+        while timeout > 0:
+            try:
+                print("polling for moto server")
+                r = requests.get(endpoint_uri)
+                if r.ok:
+                    break
+            except:
+                pass
+            timeout -= 0.1
+            time.sleep(0.1)
+        print("server up")
+        yield
+        print("moto done")
+        proc.terminate()
+        proc.wait()

--- a/s3fs/tests/derived/s3fs_test.py
+++ b/s3fs/tests/derived/s3fs_test.py
@@ -1,0 +1,14 @@
+import fsspec.tests.abstract as abstract
+from s3fs.tests.derived.s3fs_fixtures import S3fsFixtures
+
+
+class TestS3fsCopy(abstract.AbstractCopyTests, S3fsFixtures):
+    pass
+
+
+class TestS3fsGet(abstract.AbstractGetTests, S3fsFixtures):
+    pass
+
+
+class TestS3fsPut(abstract.AbstractPutTests, S3fsFixtures):
+    pass


### PR DESCRIPTION
This adds testing using the abstract test harness introduced into `fsspec` in fsspec/filesystem_spec#1216. It is not intended to be merged yet, my intention is to leave it as an open PR that I can keep pushing to and rerun the CI as I add more tests to `fsspec` that will be picked up here.

It demonstrates what is required for a class derived from `fsspec.AbstractFileSystem` to inherit and run the new test suite. The `s3fs_test.py` file will run all tests from the `fsspec.Abstract<whatever>Tests` by inheriting from them. If a test is not appropriate for this `fsspec` implementation then it would be `pytest.skipped` in this file. Most of the new code is setting up a filesystem in a repeatable way for the tests, and most of this is copy-and-pasted (with minor modifications) from the directory above. I've duplicated this code rather than importing it from the existing code as I'd like to keep the new tests isolated from the old ones initially. It might be possible to replace all of the old tests with new ones within the new test harness but it is too early to say whether this will be likely yet.

This is all very experimental still. We need to add a fairly comprehensive set of tests to this framework before we can be sure that it will work and be easy to maintain.