### PR TITLE
Conform variable name in example 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,10 +29,10 @@ Simple locate and read a file:
 .. code-block:: python
 
    >>> import s3fs
-   >>> fs = s3fs.S3FileSystem(anon=True)
-   >>> fs.ls('my-bucket')
+   >>> s3 = s3fs.S3FileSystem(anon=True)
+   >>> s3.ls('my-bucket')
    ['my-file.txt']
-   >>> with fs.open('my-bucket/my-file.txt', 'rb') as f:
+   >>> with s3.open('my-bucket/my-file.txt', 'rb') as f:
    ...     print(f.read())
    b'Hello, world'
 


### PR DESCRIPTION
Aligns with the other examples on the page. `s3fs.S3FileSystem` object is assigned the name `s3` for all other examples