### PR TITLE
Fix bug were SlowDown retries could result in BadDigest failures for small files

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1107,10 +1107,10 @@ class S3FileSystem(AsyncFileSystem):
 
         with open(lpath, "rb") as f0:
             if size < min(5 * 2**30, 2 * chunksize):
+                chunk = f0.read()
                 await self._call_s3(
-                    "put_object", Bucket=bucket, Key=key, Body=f0, **kwargs
+                    "put_object", Bucket=bucket, Key=key, Body=chunk, **kwargs
                 )
-                callback.relative_update(size)
             else:
 
                 mpu = await self._call_s3(

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1111,6 +1111,7 @@ class S3FileSystem(AsyncFileSystem):
                 await self._call_s3(
                     "put_object", Bucket=bucket, Key=key, Body=chunk, **kwargs
                 )
+                callback.relative_update(size)
             else:
 
                 mpu = await self._call_s3(


### PR DESCRIPTION
When doing _put_file with small files, a retryable error like `SlowDown` could ultimately result in `BadDigest` failures.
The `botocore` code would read the entire file passed into `put_object`. The `error_wrapper` would then retry with the same file object but nothing would seek back to the start again.

This is now fixed by not using a file object but, similar to the multi-part upload, read the content into bytes first. These bytes can be retried without seeking. This resolves the problem.