### PR TITLE
add size property to enable _cp_file

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2296,6 +2296,13 @@ class S3AsyncStreamedFile(AbstractAsyncStreamedFile):
         self.mode = mode
         self.r = None
         self.loc = 0
+        self._details = None
+
+    @property
+    async def size(self):
+        if self._details is None:
+            self._details = await self.fs._info(self.path)
+        return self._details["size"]
 
     async def read(self, length=-1):
         if self.r is None:


### PR DESCRIPTION
fsspec's generic filesystem `_cp_file` functionality checks the size of the file before reading it, causing the currently s3 async implementation to fail. This PR calls `_info` to retrieve and cache the file size when needed. Once this bug in fsspec is fixed (https://github.com/fsspec/filesystem_spec/pull/1281) it should be possible to use the generic filesystem cp functionality with s3fs.