### PR TITLE
Remove unwanted print statement

### DIFF
--- a/s3fs/tests/derived/s3fs_fixtures.py
+++ b/s3fs/tests/derived/s3fs_fixtures.py
@@ -18,7 +18,6 @@ endpoint_uri = "http://127.0.0.1:%s/" % port
 class S3fsFixtures(AbstractFixtures):
     @pytest.fixture(scope="class")
     def fs(self, _s3_base, _get_boto3_client):
-        print("FS")
         client = _get_boto3_client
         client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
 


### PR DESCRIPTION
I accidentally left a `print` statement in PR https://github.com/fsspec/s3fs/pull/713, this removes it. It wouldn't have done any harm as it is only in the test code, but I should certainly have checked more carefully.