### PR TITLE
Add flask_cors as explicit test dependency

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,6 @@
 mock; python_version < '3.3'
 moto>=4
 flask
+flask_cors
 pytest>=4.2.0
 pytest-env


### PR DESCRIPTION
When installing `requirements.txt` and `test_requirements.txt`, `moto_server` cannot start as it is missing the `flask_cors` dependency:
```
(env) hemker@machine:~/dev/s3fs [main]$ moto_server s3 -p 5555
/home/hemker/dev/s3fs/env/lib/python3.10/site-packages/moto/moto_server/werkzeug_app.py:13: UserWarning: When using MotoServer, ensure that you install moto[server] to have all dependencies!

  warnings.warn(
Traceback (most recent call last):
  File "/home/hemker/dev/s3fs/env/bin/moto_server", line 5, in <module>
    from moto.server import main
  File "/home/hemker/dev/s3fs/env/lib/python3.10/site-packages/moto/server.py", line 10, in <module>
    from moto.moto_server.werkzeug_app import (
  File "/home/hemker/dev/s3fs/env/lib/python3.10/site-packages/moto/moto_server/werkzeug_app.py", line 9, in <module>
    from flask_cors import CORS
ModuleNotFoundError: No module named 'flask_cors'
```
Seems that it was implicitly pulled before.