### PR TITLE
For exists(), more precise error handling.

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1019,12 +1019,17 @@ class S3FileSystem(AsyncFileSystem):
                     "list_objects_v2", MaxKeys=1, Bucket=bucket, **self.req_kw
                 )
                 return True
-            except Exception:
+            except (FileNotFoundError, PermissionError):
                 pass
             try:
                 await self._call_s3("get_bucket_location", Bucket=bucket, **self.req_kw)
                 return True
-            except Exception:
+            except FileNotFoundError:
+                return False
+            except PermissionError as e:
+                logger.warning(
+                    "Bucket %s doesn't exist or you don't have access to it.",
+                    bucket)
                 return False
 
     exists = sync_wrapper(_exists)


### PR DESCRIPTION
This PR improves the error handling logic for `s3fs.S3FileSystem.exists()` and resolves #750 

First change is that there is no longer a generic `except Exception` block, meaning that e.g. `ConnectionError` now correctly raises an error instead of returning `False` when querying a bucket.

Second change is that a warning is now logged when attempting to query the existence of a bucket that the user does not have access to - this is important since the bucket might actually exist. This is in line with Amazon's proposed behavior, see [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/example_s3_HeadBucket_section.html).

For more information on this, see related issue #750.

