### PR TITLE
Invalidate cache in rm_file

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1879,6 +1879,7 @@ class S3FileSystem(AsyncFileSystem):
 
     async def _rm_file(self, path, **kwargs):
         bucket, key, _ = self.split_path(path)
+        self.invalidate_cache(path)
 
         try:
             await self._call_s3("delete_object", Bucket=bucket, Key=key)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2636,3 +2636,20 @@ def test_async_stream(s3_base):
 
     asyncio.run(read_stream())
     assert b"".join(out) == data
+
+
+def test_rm_invalidates_cache(s3):
+    # Issue 761: rm_file does not invalidate cache
+    fn = test_bucket_name + "/2014-01-01.csv"
+    assert s3.exists(fn)
+    assert fn in s3.ls(test_bucket_name)
+    s3.rm(fn)
+    assert not s3.exists(fn)
+    assert fn not in s3.ls(test_bucket_name)
+
+    fn = test_bucket_name + "/2014-01-02.csv"
+    assert s3.exists(fn)
+    assert fn in s3.ls(test_bucket_name)
+    s3.rm_file(fn)
+    assert not s3.exists(fn)
+    assert fn not in s3.ls(test_bucket_name)


### PR DESCRIPTION
Fixes #761.

`_rm()` invalidates the cache whereas `_rm_file()` did not but now does.