### PR TITLE
Better double asterisk support

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -969,6 +969,8 @@ class S3FileSystem(AsyncFileSystem):
                     for o in files
                     if o["name"].rstrip("/") == path and o["type"] != "directory"
                 ]
+                if not files:
+                    raise FileNotFoundError(path)
             if detail:
                 return files
         return files if detail else sorted([o["name"] for o in files])

--- a/s3fs/tests/derived/s3fs_fixtures.py
+++ b/s3fs/tests/derived/s3fs_fixtures.py
@@ -61,6 +61,7 @@ class S3fsFixtures(AbstractFixtures):
     def fs_path(self):
         return test_bucket_name
 
+    @pytest.fixture
     def supports_empty_directories(self):
         return False
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -281,7 +281,8 @@ def test_info(s3):
     s3.mkdir(new_parent)
     with pytest.raises(FileNotFoundError):
         s3.info(new_parent)
-    s3.ls(new_parent)
+    with pytest.raises(FileNotFoundError):
+        s3.ls(new_parent)
     with pytest.raises(FileNotFoundError):
         s3.info(new_parent)
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2071,9 +2071,13 @@ def test_via_fsspec(s3):
     import fsspec
 
     s3.mkdir("mine")
-    with fsspec.open("mine/oi", "wb") as f:
+    with fsspec.open(
+        "s3://mine/oi", "wb", client_kwargs={"endpoint_url": endpoint_uri}
+    ) as f:
         f.write(b"hello")
-    with fsspec.open("mine/oi", "rb") as f:
+    with fsspec.open(
+        "s3://mine/oi", "rb", client_kwargs={"endpoint_url": endpoint_uri}
+    ) as f:
         assert f.read() == b"hello"
 
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2151,11 +2151,11 @@ def test_shallow_find(s3):
     ``maxdepth=1``, the results of ``find`` should be the same as those of
     ``ls``, without returning subdirectories.  See also issue 378.
     """
-
-    assert s3.ls(test_bucket_name) == s3.find(
+    ls_output = s3.ls(test_bucket_name)
+    assert sorted(ls_output + [test_bucket_name]) == s3.find(
         test_bucket_name, maxdepth=1, withdirs=True
     )
-    assert s3.ls(test_bucket_name) == s3.glob(test_bucket_name + "/*")
+    assert ls_output == s3.glob(test_bucket_name + "/*")
 
 
 def test_multi_find(s3):


### PR DESCRIPTION
This PR updates the `s3fs` implementation to support updates made in the [Better double asterisks ** support](https://github.com/fsspec/filesystem_spec/pull/1329) pull request in the `filesystem_spec` repo.

Successful run: https://github.com/fsspec/filesystem_spec/actions/runs/5847462518/job/15915309957