### PR TITLE
fill dircache on open

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -265,7 +265,7 @@ def test_info(s3):
     s3.touch(b)
     info = s3.info(a)
     linfo = s3.ls(a, detail=True)[0]
-    assert abs(info.pop("LastModified") - linfo.pop("LastModified")).seconds < 1
+    assert abs(info["LastModified"] - linfo["LastModified"]).seconds < 1
     info.pop("VersionId")
     info.pop("ContentType")
     linfo.pop("Key")
@@ -2203,6 +2203,14 @@ def test_version_sizes(s3):
         with s3.open(path, version_id=version_id) as f:
             with gzip.GzipFile(fileobj=f) as zfp:
                 zfp.read()
+
+
+def test_list_then_pipe_info(s3):
+    path = f"{test_bucket_name}/list_then_pipe_info.txt"
+    s3.touch(path)
+    s3.ls(test_bucket_name)
+    s3.pipe_file(path, b"good morning!")
+    assert s3.size(path) == 13
 
 
 def test_find_no_side_effect(s3):


### PR DESCRIPTION
When opening a file for reading, the returned file info is not persisted in the `dircache`. This causes consecutive calls to the same file to trigger additional `HeadObject` requests.

```py
with fs.open(bucket + '/file.csv', 'rb') as f:
    f.read()

with fs.open(bucket + '/file.csv', 'rb') as f:
    f.read()
```

Expected result is that only one HeadObject request is made instead of two.

If you were to do a `fs.listdir(dataset_base_url)` before the `open()` calls, no `HeadObject` request would be triggered all because the cache will be filled from the list operation.

This PR will fill the dircache with the result from the `HeadObject` operation to prevent subsequent redundant requests.

This also fixes a bug where a file's size would not be reported properly if the directory was first listed, and a file was overwritten or pipe_file was used after a directory listing due to missing cache invalidation.
