### PR TITLE
Fix for issue #672

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2254,7 +2254,7 @@ class S3File(AbstractBufferedFile):
             )
 
             part_header = {"PartNumber": part, "ETag": out["ETag"]}
-            if out["ChecksumSHA256"]:
+            if "ChecksumSHA256" in out:
                 part_header["ChecksumSHA256"] = out["ChecksumSHA256"]
             self.parts.append(part_header)
 

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2150,7 +2150,10 @@ class S3File(AbstractBufferedFile):
                 UploadId=self.mpu["UploadId"],
                 CopySource=self.path,
             )
-            self.parts.append({"PartNumber": 1, "ETag": out["CopyPartResult"]["ETag"]})
+            part_header = {"PartNumber": part, "ETag": out["ETag"]}
+            if out["ChecksumSHA256"]:
+                part_header["ChecksumSHA256"] = out["ChecksumSHA256"]
+            self.parts.append(part_header)
 
     def metadata(self, refresh=False, **kwargs):
         """Return metadata of file.

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2150,10 +2150,7 @@ class S3File(AbstractBufferedFile):
                 UploadId=self.mpu["UploadId"],
                 CopySource=self.path,
             )
-            part_header = {"PartNumber": part, "ETag": out["ETag"]}
-            if out["ChecksumSHA256"]:
-                part_header["ChecksumSHA256"] = out["ChecksumSHA256"]
-            self.parts.append(part_header)
+            self.parts.append({"PartNumber": 1, "ETag": out["CopyPartResult"]["ETag"]})
 
     def metadata(self, refresh=False, **kwargs):
         """Return metadata of file.
@@ -2256,7 +2253,10 @@ class S3File(AbstractBufferedFile):
                 Key=key,
             )
 
-            self.parts.append({"PartNumber": part, "ETag": out["ETag"]})
+            part_header = {"PartNumber": part, "ETag": out["ETag"]}
+            if out["ChecksumSHA256"]:
+                part_header["ChecksumSHA256"] = out["ChecksumSHA256"]
+            self.parts.append(part_header)
 
         if self.autocommit and final:
             self.commit()

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -375,6 +375,9 @@ def test_checksum(s3):
     s3.checksum(path1, refresh=True)
 
 def test_multi_checksum(s3):
+    # Moto accepts the request to add checksum, and accepts the checksum mode,
+    # but doesn't actually return the checksum
+    # So, this is mostly a stub test
     file_key = "checksum"
     path = test_bucket_name + "/" + file_key
     s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri},
@@ -383,7 +386,8 @@ def test_multi_checksum(s3):
         f.write(b"0" * (5 * 2**20 + 1)) # starts multipart and puts first part
         f.write(b"data") # any extra data
     assert s3.cat(path) == b"0" * (5 * 2**20 + 1) + b"data"
-    sync(s3.loop, s3.s3.head_object, Bucket=test_bucket_name, Key=file_key, ChecksumMode='ENABLED')
+    FileHead = sync(s3.loop, s3.s3.head_object, Bucket=test_bucket_name, Key=file_key, ChecksumMode='ENABLED')
+    # assert "ChecksumSHA256" in FileHead
 
 test_xattr_sample_metadata = {"testxattr": "1"}
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -374,9 +374,16 @@ def test_checksum(s3):
     )
     s3.checksum(path1, refresh=True)
 
+def test_multi_checksum(s3):
+    path = test_bucket_name + "/tmp/checksum"
+    s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri},
+        s3_additional_kwargs={"ChecksumAlgorithm": "SHA256"})
+    with s3.open(path, "wb", blocksize=5 * 2**20, ) as f:
+        f.write(b"0" * (5 * 2**20 + 1)) # starts multipart and puts first part
+        f.write(b"data") # any extra data
+    assert s3.cat(path) == b"0" * (5 * 2**20 + 1) + b"data"
 
 test_xattr_sample_metadata = {"testxattr": "1"}
-
 
 def test_xattr(s3):
     bucket, key = (test_bucket_name, "tmp/test/xattr")

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -375,13 +375,15 @@ def test_checksum(s3):
     s3.checksum(path1, refresh=True)
 
 def test_multi_checksum(s3):
-    path = test_bucket_name + "/tmp/checksum"
+    path = test_bucket_name
+    file_key = "/tmp/checksum"
     s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri},
         s3_additional_kwargs={"ChecksumAlgorithm": "SHA256"})
-    with s3.open(path, "wb", blocksize=5 * 2**20, ) as f:
+    with s3.open(path + file_key, "wb", blocksize=5 * 2**20, ) as f:
         f.write(b"0" * (5 * 2**20 + 1)) # starts multipart and puts first part
         f.write(b"data") # any extra data
-    assert s3.cat(path) == b"0" * (5 * 2**20 + 1) + b"data"
+    assert s3.cat(path + file_key) == b"0" * (5 * 2**20 + 1) + b"data"
+    sync(s3.loop, s3.s3.head_object, Bucket=test_bucket_name, Key=file_key, ChecksumMode='ENABLED')
 
 test_xattr_sample_metadata = {"testxattr": "1"}
 

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -375,14 +375,14 @@ def test_checksum(s3):
     s3.checksum(path1, refresh=True)
 
 def test_multi_checksum(s3):
-    path = test_bucket_name
-    file_key = "/tmp/checksum"
+    file_key = "checksum"
+    path = test_bucket_name + "/" + file_key
     s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri},
         s3_additional_kwargs={"ChecksumAlgorithm": "SHA256"})
-    with s3.open(path + file_key, "wb", blocksize=5 * 2**20, ) as f:
+    with s3.open(path, "wb", blocksize=5 * 2**20, ) as f:
         f.write(b"0" * (5 * 2**20 + 1)) # starts multipart and puts first part
         f.write(b"data") # any extra data
-    assert s3.cat(path + file_key) == b"0" * (5 * 2**20 + 1) + b"data"
+    assert s3.cat(path) == b"0" * (5 * 2**20 + 1) + b"data"
     sync(s3.loop, s3.s3.head_object, Bucket=test_bucket_name, Key=file_key, ChecksumMode='ENABLED')
 
 test_xattr_sample_metadata = {"testxattr": "1"}

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -374,22 +374,38 @@ def test_checksum(s3):
     )
     s3.checksum(path1, refresh=True)
 
+
 def test_multi_checksum(s3):
     # Moto accepts the request to add checksum, and accepts the checksum mode,
     # but doesn't actually return the checksum
     # So, this is mostly a stub test
     file_key = "checksum"
     path = test_bucket_name + "/" + file_key
-    s3 = S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_uri},
-        s3_additional_kwargs={"ChecksumAlgorithm": "SHA256"})
-    with s3.open(path, "wb", blocksize=5 * 2**20, ) as f:
-        f.write(b"0" * (5 * 2**20 + 1)) # starts multipart and puts first part
-        f.write(b"data") # any extra data
+    s3 = S3FileSystem(
+        anon=False,
+        client_kwargs={"endpoint_url": endpoint_uri},
+        s3_additional_kwargs={"ChecksumAlgorithm": "SHA256"},
+    )
+    with s3.open(
+        path,
+        "wb",
+        blocksize=5 * 2**20,
+    ) as f:
+        f.write(b"0" * (5 * 2**20 + 1))  # starts multipart and puts first part
+        f.write(b"data")  # any extra data
     assert s3.cat(path) == b"0" * (5 * 2**20 + 1) + b"data"
-    FileHead = sync(s3.loop, s3.s3.head_object, Bucket=test_bucket_name, Key=file_key, ChecksumMode='ENABLED')
+    FileHead = sync(
+        s3.loop,
+        s3.s3.head_object,
+        Bucket=test_bucket_name,
+        Key=file_key,
+        ChecksumMode="ENABLED",
+    )
     # assert "ChecksumSHA256" in FileHead
 
+
 test_xattr_sample_metadata = {"testxattr": "1"}
+
 
 def test_xattr(s3):
     bucket, key = (test_bucket_name, "tmp/test/xattr")


### PR DESCRIPTION
This is a fix for #672

Creates a local `part_header` dictionary, then checks if the `ChecksumSHA256` should be added. 

While this fixes my specific issue, there are probably other headers that should be checked for and added if they exist. 

