### PR TITLE
Await loop.create_task in core.py, fix for #781

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -543,7 +543,7 @@ class S3FileSystem(AsyncFileSystem):
         if loop is not None and loop.is_running():
             try:
                 loop = asyncio.get_event_loop()
-                loop.create_task(s3.__aexit__(None, None, None))
+                await loop.create_task(s3.__aexit__(None, None, None))
                 return
             except RuntimeError:
                 pass


### PR DESCRIPTION
Await loop.create_task in core.py, fix for https://github.com/fsspec/s3fs/issues/781:
* https://github.com/fsspec/s3fs/issues/781

This should resolve the following warning message:
```python3
/opt/python/lib/python3.10/site-packages/s3fs/core.py:546: RuntimeWarning: coroutine 'ClientCreatorContext.__aexit__' was never awaited
  loop.create_task(s3.__aexit__(None, None, None))
```