### PR TITLE
Fix `ClientPayloadError` while reading

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2374,6 +2374,6 @@ async def _inner_fetch(fs, bucket, key, version_id, start, end, req_kw=None):
         try:
             return await resp["Body"].read()
         finally:
-            await resp["Body"].close()
+            resp["Body"].close()
 
     return await _error_wrapper(_call_and_read, retries=fs.retries)

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -2362,12 +2362,18 @@ def _fetch_range(fs, bucket, key, version_id, start, end, req_kw=None):
 
 
 async def _inner_fetch(fs, bucket, key, version_id, start, end, req_kw=None):
-    resp = await fs._call_s3(
-        "get_object",
-        Bucket=bucket,
-        Key=key,
-        Range="bytes=%i-%i" % (start, end - 1),
-        **version_id_kw(version_id),
-        **req_kw,
-    )
-    return await resp["Body"].read()
+    async def _call_and_read():
+        resp = await fs._call_s3(
+            "get_object",
+            Bucket=bucket,
+            Key=key,
+            Range="bytes=%i-%i" % (start, end - 1),
+            **version_id_kw(version_id),
+            **req_kw,
+        )
+        try:
+            return await resp["Body"].read()
+        finally:
+            await resp["Body"].close()
+
+    return await _error_wrapper(_call_and_read, retries=fs.retries)


### PR DESCRIPTION
Closes https://github.com/fsspec/s3fs/issues/786

The `_call_and_read` pattern was already implemented for `_cat_file` in https://github.com/fsspec/s3fs/pull/601 so I'm just applying this pattern again. I don't know the library well enough to judge if this can be refactored somehow else but I would prefer to separate fix from the refactor