### PR TITLE
Ensure dircache directories contain their subdirectories

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -851,6 +851,13 @@ class S3FileSystem(AsyncFileSystem):
                         thisdircache[ppar].append(d)
             if par in sdirs:
                 thisdircache[par].append(o)
+
+        # Explicitly add directories to their parents in the dircache
+        for d in dirs:
+            par = self._parent(d["name"])
+            if par in thisdircache:
+                thisdircache[par].append(d)
+
         if not prefix:
             for k, v in thisdircache.items():
                 if k not in self.dircache and len(k) >= len(path):


### PR DESCRIPTION
Fixes #773.

The `dircache` was inconsistent when calling `find` with different `maxdepth` values. The fix is to ensure that `_find(maxdepth=None)` explicitly adds entries for each found directory under its parent directory key to make it consistent with `_find` that uses integer `maxdepth` and has a different code path.

I think this is another consequence of `s3fs` directories not really existing so they need special handling.