### PR TITLE
Remove CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/env.yaml
-          extra-specs: python=${{ matrix.python-version }}
+          create-args: >-
+            python=${{ matrix.PY }}
 
       - name: Install
         shell: bash -l {0}
@@ -42,6 +43,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Remove warnings in CI:

- Replace deprecated `mamba-org/provision-with-micromamba` with `mamba-org/setup-micromamba`.
- Specify `python-version` in `lint` action.
- Update versions of actions that are using deprecated `node12`.