### PR TITLE
Update requirements.txt For aiobotocore 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=2.6.0
+aiobotocore~=2.7.0
 fsspec==2023.9.2
 aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
2.7 contains [up to date botocore](https://github.com/aio-libs/aiobotocore/pull/1037) dependencies and support for urllib3 2.0. Increasing the version here should save some dependency headaches (I know it will for me!).