### PR TITLE
Make S3FileSystem.protocol type tuple[str, ...]

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -257,7 +257,7 @@ class S3FileSystem(AsyncFileSystem):
     retries = 5
     read_timeout = 15
     default_block_size = 5 * 2**20
-    protocol = ["s3", "s3a"]
+    protocol = ("s3", "s3a")
     _extra_tokenize_attributes = ("default_block_size",)
 
     def __init__(


### PR DESCRIPTION
Hello,

this PR makes `S3FileSystem` more spec compliant by changing the protocol type from `list[str]` to `tuple[str, ...]` as required by fsspec: 

https://github.com/fsspec/filesystem_spec/blob/6aa8a9a888f8d7ce2c721f6896f1ffabde84ef05/fsspec/spec.py#L107

This caused an issue when I was using s3fs together with ReferenceFileSystem. See fsspec/filesystem_spec#1395

Let me know if I should also add some sort of test to ensure the protocol type.

Cheers,
Andreas