### PR TITLE
Reduce the ListRequests for a recursive put for targets ending in "/"

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2613,11 +2613,12 @@ def test_get_directory_recursive(s3, tmpdir):
         assert target_fs.find(target) == [os.path.join(target, "file")]
 
 
-def test_put_directory_recursive(s3, tmpdir):
+def test_put_directory_recursive(s3, tmpdir, request_count):
     src = os.path.join(tmpdir, "src")
-    src_file = os.path.join(src, "file")
+    deep_src_path = os.path.join(src, "very", "deep")
+    src_file = os.path.join(deep_src_path, "file")
     source_fs = fsspec.filesystem("file")
-    source_fs.mkdir(src)
+    source_fs.mkdir(deep_src_path)
     source_fs.touch(src_file)
 
     target = test_bucket_name + "/target"
@@ -2629,18 +2630,42 @@ def test_put_directory_recursive(s3, tmpdir):
         assert s3.isdir(target)
 
         if loop == 0:
-            assert s3.find(target) == [target + "/file"]
+            assert s3.find(target) == [target + "/very/deep/file"]
         else:
-            assert sorted(s3.find(target)) == [target + "/file", target + "/src/file"]
+            assert sorted(s3.find(target)) == [target + "/src/very/deep/file", target + "/very/deep/file"]
 
     s3.rm(target, recursive=True)
 
     # put with slash
     assert not s3.exists(target)
+
+
     for loop in range(2):
+        s3.dircache.clear()
+        request_count.clear()
+
         s3.put(src + "/", target, recursive=True)
+
+        assert request_count.get("PutObject", 0) == 1
+        assert request_count.get("ListObjectsV2", 0) <= 1
+
         assert s3.isdir(target)
-        assert s3.find(target) == [target + "/file"]
+        assert s3.find(target) == [target + "/very/deep/file"]
+
+
+@pytest.fixture()
+def request_count(s3):
+    count = {}
+
+    def count_requests(request, operation_name, **kwargs):
+        nonlocal count
+        count[operation_name] = count.get(operation_name, 0) + 1
+
+    s3.s3.meta.events.register("request-created.s3", count_requests)
+
+    yield count
+
+    s3.s3.meta.events.unregister("request-created.s3", count_requests)
 
 
 def test_cp_two_files(s3):


### PR DESCRIPTION
Recently we have found that `s3.put("/var/tmp/", "s3://test/wibble")` and `s3.put("/var/tmp/", "s3://test/wibble/")` result in one ListObjectsV2 per directory which is written.

Investigation indicates it is the _exists check to see if the bucket you are writing to really exists. It does this for every directory. In practice we have seen 12 ListObjectsV2 calls for 1 PutObject.

This pull request resolves this for targets with do not end in "/" because it leverages the dircache state from the `isdir()` call to see if this bucket already exists. Targets which do end in "/" skip the `isdir()` call and still exhibit the old behaviour. Best would be if there would be a way to cache the _exists result or maybe disable the bucket creation entirely. 
I didn't know how to cache the _exists result in the current `DirCache` setup.

To test this properly I created a fixture which allows you to count the requests made to S3. That may be useful for other similar problems as well.