### PR TITLE
Try anon=True if no credentials are supplied or found

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -474,10 +474,13 @@ class S3FileSystem(AsyncFileSystem):
         if self.session is None:
             self.session = aiobotocore.session.AioSession(**self.kwargs)
 
+        # creating credentials resolver which enables loading credentials from configs/environment variables see
+        # https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L2043
         cred_resolver = create_credential_resolver(self.session, region_name=self.session._last_client_region_used)
         credentials = cred_resolver.load_credentials()
 
         if credentials is None and self.key is None and self.secret is None and self.token is None and not self.anon:
+            logger.debug("No credentials given/found, setting `anon` to True.")
             self.anon = True
         else:
             self.key = credentials.access_key

--- a/s3fs/tests/test_mapping.py
+++ b/s3fs/tests/test_mapping.py
@@ -52,22 +52,6 @@ def test_with_data(s3):
     assert list(d) == []
 
 
-def test_complex_keys(s3):
-    d = s3.get_mapper(root)
-    d[1] = b"hello"
-    assert d[1] == b"hello"
-    del d[1]
-
-    d[1, 2] = b"world"
-    assert d[1, 2] == b"world"
-    del d[1, 2]
-
-    d["x", 1, 2] = b"hello world"
-    assert d["x", 1, 2] == b"hello world"
-
-    assert ("x", 1, 2) in d
-
-
 def test_clear_empty(s3):
     d = s3.get_mapper(root)
     d.clear()

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -167,9 +167,9 @@ def test_simple(s3):
 
 
 def test_auto_anon(s3, monkeypatch):
-    monkeypatch.delenv("AWS_ACCESS_KEY_ID")
-    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY")
-    monkeypatch.delenv("AWS_SESSION_TOKEN")
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
 
     fs = S3FileSystem(skip_instance_cache=True, endpoint_url=endpoint_uri)
     fs.s3

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -166,6 +166,16 @@ def test_simple(s3):
         assert out == data
 
 
+def test_auto_anon(s3, monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID")
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY")
+    monkeypatch.delenv("AWS_SESSION_TOKEN")
+
+    fs = S3FileSystem(skip_instance_cache=True, endpoint_url=endpoint_uri)
+    fs.s3
+    assert fs.anon
+
+
 def test_with_size(s3):
     data = b"a" * (10 * 2**20)
 

--- a/s3fs/utils.py
+++ b/s3fs/utils.py
@@ -1,7 +1,6 @@
 import errno
 import logging
 from contextlib import contextmanager, AsyncExitStack
-from botocore.exceptions import ClientError
 
 
 logger = logging.getLogger("s3fs")
@@ -31,26 +30,13 @@ class S3BucketRegionCache:
         if bucket_name in self._buckets:
             return self._buckets[bucket_name]
 
-        general_client = await self.get_client()
         if bucket_name is None:
-            return general_client
+            # general client
+            return await self.get_client()
 
-        try:
-            response = await general_client.head_bucket(Bucket=bucket_name)
-        except ClientError as e:
-            region = (
-                e.response["ResponseMetadata"]
-                .get("HTTPHeaders", {})
-                .get("x-amz-bucket-region")
-            )
-            if not region:
-                logger.debug(
-                    "RC: HEAD_BUCKET call for %r has failed, returning the general client",
-                    bucket_name,
-                )
-                return general_client
-        else:
-            region = response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"]
+        region = get_bucket_region(
+            bucket_name
+        )  # this is sync - matters? can reuse some aiohttp session?
 
         if region not in self._regions:
             logger.debug(
@@ -68,6 +54,7 @@ class S3BucketRegionCache:
         return client
 
     async def get_client(self):
+        # general, non-regional client
         if not self._client:
             self._client = await self._stack.enter_async_context(
                 self._session.create_client("s3", **self._client_kwargs)
@@ -86,6 +73,15 @@ class S3BucketRegionCache:
 
     async def __aexit__(self, *exc_args):
         await self.clear()
+
+
+def get_bucket_region(bucket):
+    """Simple way to locate bucket"""
+    import requests
+
+    return requests.head(f"https://s3.amazonaws.com/{bucket}").headers[
+        "x-amz-bucket-region"
+    ]
 
 
 class FileExpired(IOError):


### PR DESCRIPTION
This PR tries to use anon=True if no credentials are supplied or found in config files

The print statement should probably be changed to a warning also help with the tests would be appreciated.

 - [x] Closes #675 
 - [ ] Tests added
 - [ ] Fully documented