### PR TITLE
Use .get for LastModified to mitigate KeyError

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1309,7 +1309,7 @@ class S3FileSystem(AsyncFileSystem):
                 )
                 return {
                     "ETag": out.get("ETag", ""),
-                    "LastModified": out["LastModified"],
+                    "LastModified": out("LastModified", ""),
                     "size": out["ContentLength"],
                     "name": "/".join([bucket, key]),
                     "type": "file",

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1309,7 +1309,7 @@ class S3FileSystem(AsyncFileSystem):
                 )
                 return {
                     "ETag": out.get("ETag", ""),
-                    "LastModified": out("LastModified", ""),
+                    "LastModified": out.get("LastModified", ""),
                     "size": out["ContentLength"],
                     "name": "/".join([bucket, key]),
                     "type": "file",


### PR DESCRIPTION
This PR addresses the issue where a KeyError is raised because the `LastModified` attribute is not on a retrieved object