### PR TITLE
Relax aiobotocore versions to < 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} - AioBotocore ${{ matrix.aiobotocore-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        aiobotocore-version: [">=2.5.4,<2.6.0", ">=2.7.0,<2.8.0", ">=2.8.0,<2.9.0", "<3.0.0"]
 
     env:
       BOTO_CONFIG: /dev/null
@@ -33,7 +34,9 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install git+https://github.com/fsspec/filesystem_spec
+          pip install --upgrade "aiobotocore${{ matrix.aiobotocore-version }}" boto3  # boto3 to ensure compatibility
           pip install . --no-deps
+          pip show aiobotocore boto3 botocore
 
       - name: Run Tests
         shell: bash -l {0}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiobotocore~=2.7.0
+aiobotocore>=2.5.4,<3.0.0
 fsspec==2023.10.0
 aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
This relaxes the accepted aiobotocore versions
to < 3.0.0 and provides a testing matrix against
all recent knowmn versions, that can be extended
at will.

I have been a bit daring and made it < 3.0.0 as the 
whole matrix passed. 

The CI will provide information on what exact minor version of 
aiobotocore is tested against including what boto3. As 
boto3 is synced there is some backtracking done by pip,
but I kept that as it is. We could provide some hints if required
but I thought it was clearer this way.

@martindurant @freddy-fostvedt @lou-k @manugarri
