### PR TITLE
Fix the cache lookup in _info

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1293,7 +1293,7 @@ class S3FileSystem(AsyncFileSystem):
                     if out:
                         return out[0]
                 else:
-                    out = [o for o in out if o["name"] == path]
+                    out = [o for o in out if o["name"] == fullpath]
                     if out:
                         return out[0]
                     return {"name": path, "size": 0, "type": "directory"}

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -271,7 +271,7 @@ def test_info(s3):
     s3.ls(parent)  # fill the cache with parent dir
     assert s3.info(a) == s3.dircache[parent][0]  # correct value
     assert id(s3.info(a)) == id(s3.dircache[parent][0])  # is object from cache
-    assert id(s3.info(f'/{a}')) == id(s3.dircache[parent][0])  # is object from cache
+    assert id(s3.info(f"/{a}")) == id(s3.dircache[parent][0])  # is object from cache
 
     new_parent = test_bucket_name + "/foo"
     s3.mkdir(new_parent)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -271,6 +271,7 @@ def test_info(s3):
     s3.ls(parent)  # fill the cache with parent dir
     assert s3.info(a) == s3.dircache[parent][0]  # correct value
     assert id(s3.info(a)) == id(s3.dircache[parent][0])  # is object from cache
+    assert id(s3.info(f'/{a}')) == id(s3.dircache[parent][0])  # is object from cache
 
     new_parent = test_bucket_name + "/foo"
     s3.mkdir(new_parent)


### PR DESCRIPTION
The info function retrieved the `fullpath` from the cache in its initial lookup but used the given `path` (which is a user given variable) on the second instance.

Fixed it to use `fullpath` both times.

You can reproduce the bug with the following code:
```python
# Filling the cache.
fs.isdir("/bucket")

# The cache seems ok.
print(fs.dircache._cache)

# The cache "miss" happens now because the key doesn't start with "/".
print(fs.info("/bucket/file"))
```