### PR TITLE
Update core.py

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1153,7 +1153,7 @@ class S3FileSystem(AsyncFileSystem):
         callback.set_size(size)
 
         if "ContentType" not in kwargs:
-            content_type, _ = mimetypes.guess_type(lpath)
+            content_type, _ = mimetypes.guess_type(rpath)
             if content_type is not None:
                 kwargs["ContentType"] = content_type
 


### PR DESCRIPTION
Refactor the code to improve mime type guessing by utilizing the destination file instead of relying on the source file. This change was prompted by the inconvenience of having uncompressed Minio objects when the source was a .tmp file that I would subsequently copy to .txt or .csv format.

Based on the observation, it seems there shouldn't be any drawbacks to this change, as the scenarios considered are:

1. Local files with unknown extensions being transferred to remote locations with known extensions like .txt, .csv, .json, or .zip.
2. Cases where both local and remote files have the same known extension.

The question arises: Does anyone currently utilize the scenario where local files have known extensions while remote files have unknown extensions?