### PR TITLE
fix(core): accept kwargs in get file

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1271,7 +1271,7 @@ class S3FileSystem(AsyncFileSystem):
         return out
 
     async def _get_file(
-        self, rpath, lpath, callback=_DEFAULT_CALLBACK, version_id=None
+        self, rpath, lpath, callback=_DEFAULT_CALLBACK, version_id=None, **kwargs
     ):
         if os.path.isdir(lpath):
             return

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -991,6 +991,15 @@ def test_get_file_with_callback(s3, tmpdir):
     assert cb.value == cb.size
 
 
+def test_get_file_with_kwargs(s3, tmpdir):
+    test_file = str(tmpdir.join("test.json"))
+
+    get_file_kwargs = {"max_concurency": 1, "random_kwarg": "value"}
+    s3.get_file(
+        test_bucket_name + "/test/accounts.1.json", test_file, **get_file_kwargs
+    )
+
+
 @pytest.mark.parametrize("size", [2**10, 10 * 2**20])
 def test_put_file_with_callback(s3, tmpdir, size):
     test_file = str(tmpdir.join("test.json"))


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc-s3/issues/80

It is similar to `gcsfs` and `adlfs`.

On our end it seems `max_concurrency` is passed here https://github.com/iterative/dvc-objects/blob/main/src/dvc_objects/fs/generic.py#L210 and since the new version has this attr we pass it now, which most likely leads to this error.

I'm not sure why `_gef_file` part was not yet implemented. @pmrowla might have a better idea on was it complicated, or less priority. It seems it is the natural next step to do so.