### PR TITLE
fix(s3fs): Consolidate retry logic for rate limits

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -118,10 +118,13 @@ async def _error_wrapper(func, *, args=(), kwargs=None, retries):
         except ClientError as e:
             logger.debug("Client error (maybe retryable): %s", e)
             err = e
+            wait_time = asyncio.sleep(min(1.7**i * 0.1, 15))
             if "SlowDown" in str(e):
-                await asyncio.sleep(min(1.7**i * 0.1, 15))
+                await wait_time
+            elif "reduce your request rate" in str(e):
+                await wait_time
             elif "XAmzContentSHA256Mismatch" in str(e):
-                await asyncio.sleep(min(1.7**i * 0.1, 15))
+                await wait_time
             else:
                 break
         except Exception as e:

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -118,13 +118,13 @@ async def _error_wrapper(func, *, args=(), kwargs=None, retries):
         except ClientError as e:
             logger.debug("Client error (maybe retryable): %s", e)
             err = e
-            wait_time = asyncio.sleep(min(1.7**i * 0.1, 15))
+            wait_time = min(1.7**i * 0.1, 15)
             if "SlowDown" in str(e):
-                await wait_time
+                await asyncio.sleep(wait_time)
             elif "reduce your request rate" in str(e):
-                await wait_time
+                await asyncio.sleep(wait_time)
             elif "XAmzContentSHA256Mismatch" in str(e):
-                await wait_time
+                await asyncio.sleep(wait_time)
             else:
                 break
         except Exception as e:


### PR DESCRIPTION
Retry the request when we get the error (reduce your request rate).

We have 2000+ tasks, each running in the K8s pod and uploading multiple files to a certain bucket. We get `reduce your request rate` error because s3fs doesn't retry this request

https://stackoverflow.com/questions/46787072/s3-slowdown-please-reduce-your-request-rate-exception

![image](https://github.com/fsspec/s3fs/assets/37936015/fe628000-1939-44f1-9ee9-04bfe750e750)
