### PR TITLE
_bulk_delete must always return a list, even when pathlist is empty

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1954,7 +1954,7 @@ class S3FileSystem(AsyncFileSystem):
             Must have 0 < len <= 1000
         """
         if not pathlist:
-            return
+            return []
         buckets = {self.split_path(path)[0] for path in pathlist}
         if len(buckets) > 1:
             raise ValueError("Bulk delete files should refer to only one bucket")


### PR DESCRIPTION
Fixes https://github.com/fsspec/filesystem_spec/issues/1557

_bulk_delete returned None (no return) when pathlist is empty which is incompatible with the list returned in normal operation. This causes a bug in fsspec for instance, because a list was expected. This change returns an empty list when pathlist is empty