### PR TITLE
Fix a bug in the `_upload_file_part_concurrent method`

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1275,17 +1275,14 @@ class S3FileSystem(AsyncFileSystem):
                     chunks.append(chunk)
             if not chunks:
                 break
-            if len(chunks) > 1:
-                out.extend(
-                    await asyncio.gather(
-                        *[
-                            _upload_chunk(chunk, len(out) + i)
-                            for i, chunk in enumerate(chunks, 1)
-                        ]
-                    )
+            out.extend(
+                await asyncio.gather(
+                    *[
+                        _upload_chunk(chunk, len(out) + i)
+                        for i, chunk in enumerate(chunks, 1)
+                    ]
                 )
-            else:
-                out.append(await _upload_chunk(chunks[0], len(out) + 1))
+            )
         return out
 
     async def _get_file(

--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1285,7 +1285,7 @@ class S3FileSystem(AsyncFileSystem):
                     )
                 )
             else:
-                out.append(await _upload_chunk(chunk, len(out) + 1))
+                out.append(await _upload_chunk(chunks[0], len(out) + 1))
         return out
 
     async def _get_file(


### PR DESCRIPTION
The `_upload_file_part_concurrent` method is used as part of the `put_file` function to upload the file in multiple parts (when the file is larger than a certain limit).
The function basically reads from the original file in chunks (by default 50MB) and then schedules 10 upload calls in one block. It has two different "branches": if there is more than one chunk left, it schedules them in parallel - if not, it just runs it directly. 

This last branch has a bug: it uses a variable `chunk` which is actually defined in another scope (in the for-loop before it). This leads to wrong data on the remote location: if you upload a file which has e.g. between 20 * 50MB and 21 * 50MB size, it will always be truncated to to exactly 20 * 50MB on s3. This bug is fixed in this PR.