### PR TITLE
fix a bug in the `_find`

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -852,7 +852,7 @@ class S3FileSystem(AsyncFileSystem):
         #         return super().find(path)
         #     # else: we refresh anyway, having at least two missing trees
         out = await self._lsdir(path, delimiter="", prefix=prefix, **kwargs)
-        if not out and key:
+        if (not out and key) and not prefix:
             try:
                 out = [await self._info(path)]
             except FileNotFoundError:

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2498,6 +2498,7 @@ def test_find_with_prefix(s3):
     s3.touch(test_bucket_name + "/prefixes2")
     assert len(s3.find(test_bucket_name + "/prefixes")) == 100
     assert len(s3.find(test_bucket_name, prefix="prefixes")) == 101
+    assert len(s3.find(test_bucket_name + "/prefixes", prefix="test2_")) == 0
 
     assert len(s3.find(test_bucket_name + "/prefixes/test_")) == 0
     assert len(s3.find(test_bucket_name + "/prefixes", prefix="test_")) == 100


### PR DESCRIPTION
* check if path is a directory only if '(not out and key) and not prefix'

Fixes #911 