### PR TITLE
Replace get_event_loop by get_running_loop

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -587,7 +587,7 @@ class S3FileSystem(AsyncFileSystem):
     def close_session(loop, s3):
         if loop is not None and loop.is_running():
             try:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 loop.create_task(s3.__aexit__(None, None, None))
                 return
             except RuntimeError:


### PR DESCRIPTION
Since `asyncio.get_event_loop` was deprecated since version 3.12, using `asyncio.get_running_loop()` was preferred

Ref: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop