### PR TITLE
Allow installing from main branches of fsspec and s3fs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiobotocore>=2.5.4,<3.0.0
-fsspec==2025.5.0
+fsspec>=2025.5.0
 aiohttp!=4.0.0a0, !=4.0.0a1


### PR DESCRIPTION
Pinning fsspec at 2025.5.0 means that it is not possible to install from dev branches of both fsspec and s3fs, which is useful for downstream libraries testing upstream compatibility. Would you consider instead pinning to >=2025.5.0 or 2025.5.* instead?