### PR TITLE
Add paritial read feature for open_async

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2772,6 +2772,34 @@ def test_async_stream(s3_base):
     assert b"".join(out) == data
 
 
+def test_async_stream_partial(s3_base):
+    fn = test_bucket_name + "/target"
+    data = b"hello world" * 1000
+    out = []
+
+    async def read_stream():
+        fs = S3FileSystem(
+            anon=False,
+            client_kwargs={"endpoint_url": endpoint_uri},
+            skip_instance_cache=True,
+        )
+        await fs._mkdir(test_bucket_name)
+        await fs._pipe(fn, data)
+        f = await fs.open_async(fn, mode="rb", loc=0, size=len(data) // 2)
+
+        while True:
+            got = await f.read(1000)
+            assert f.size == len(data) // 2
+            assert f.tell()
+            if not got:
+                break
+            out.append(got)
+
+    asyncio.run(read_stream())
+    assert len(b"".join(out)) == len(data) // 2
+    assert b"".join(out) == data[: len(data) // 2]
+
+
 def test_rm_invalidates_cache(s3):
     # Issue 761: rm_file does not invalidate cache
     fn = test_bucket_name + "/2014-01-01.csv"


### PR DESCRIPTION
## Feature
This feature supports to the open_async function in S3FileSystem Class, enabling efficient async reading of S3 objects without blocking the event loop. This feature is particularly valuable for applications that need to process large S3 files asynchronously or implement streaming data processing pipelines. And add a relative test for async partial read.

## Benefits
- Flexibility: Support for both full and partial file access

## Example
A paritial read example for open_async based on #871 
```python
fn = test_bucket_name + "/target"
data = b"hello world" * 1000
out = []

async def read_stream():
    fs = S3FileSystem(
        anon=False,
        client_kwargs={"endpoint_url": endpoint_uri},
        skip_instance_cache=True,
    )
    await fs._mkdir(test_bucket_name)
    await fs._pipe(fn, data)
    f = await fs.open_async(fn, mode="rb", loc=0, size=len(data) // 2)

    while True:
        got = await f.read(1000)
        assert f.size == len(data) // 2
        assert f.tell()
        if not got:
            break
        out.append(got)

asyncio.run(read_stream())
assert len(b"".join(out)) == len(data) // 2
assert b"".join(out) == data[: len(data) // 2]
```