### PR TITLE
Fixing typo in test_s3fs.py

### DIFF
--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2759,7 +2759,7 @@ def test_async_stream(s3_base):
         )
         await fs._mkdir(test_bucket_name)
         await fs._pipe(fn, data)
-        f = await fs.open_async(fn, mode="rb", block_seze=1000)
+        f = await fs.open_async(fn, mode="rb", block_size=1000)
         while True:
             got = await f.read(1000)
             assert f.size == len(data)


### PR DESCRIPTION
`block_seze` -> `block_size`