### PR TITLE
core.py: fix exclusive write for small files

### DIFF
--- a/s3fs/tests/derived/s3fs_test.py
+++ b/s3fs/tests/derived/s3fs_test.py
@@ -33,7 +33,6 @@ class TestS3fsPipe(abstract.AbstractPipeTests, S3fsFixtures):
 
 
 class TestS3fsOpen(abstract.AbstractOpenTests, S3fsFixtures):
-
     test_open_exclusive = pytest.mark.xfail(
         reason="complete_multipart_upload doesn't implement condition in moto"
     )(abstract.AbstractOpenTests.test_open_exclusive)

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2889,9 +2889,9 @@ def test_exist_after_delete(s3):
     assert not s3.exists(test_dir)
 
 
-# condition: True if running on botocore < 1.33.0
-# The below tests for exclusive writes
-old_botocore = version.parse(botocore.__version__) < version.parse("1.33.0")
+# condition: True if running on botocore < 1.36.0
+# The below tests for exclusive writes will fail on older versions of botocore.
+old_botocore = version.parse(botocore.__version__) < version.parse("1.36.0")
 
 
 @pytest.mark.xfail(

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2890,11 +2890,13 @@ def test_exist_after_delete(s3):
 
 
 # condition: True if running on botocore < 1.33.0
-# The below tests for exclusive writes 
+# The below tests for exclusive writes
 old_botocore = version.parse(botocore.__version__) < version.parse("1.33.0")
 
 
-@pytest.mark.xfail(reason="moto doesn't support IfNoneMatch for MPU when object created via MPU")
+@pytest.mark.xfail(
+    reason="moto doesn't support IfNoneMatch for MPU when object created via MPU"
+)
 def test_pipe_exclusive_big(s3):
     chunksize = 5 * 2**20  # minimum allowed
     data = b"x" * chunksize * 3
@@ -2905,10 +2907,12 @@ def test_pipe_exclusive_big(s3):
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
-@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
+@pytest.mark.xfail(
+    old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True
+)
 def test_pipe_exclusive_big_after_small(s3):
     """Test conditional MPU after creating object via put_object
-    
+
     This test is required because moto's implementation of IfNoneMatch for MPU
     only works when the object is initially created via put_object and not via
     MPU.
@@ -2920,12 +2924,19 @@ def test_pipe_exclusive_big_after_small(s3):
 
     # Now try multipart upload with mode="create" (should fail)
     with pytest.raises(FileExistsError):
-        s3.pipe(f"{test_bucket_name}/afile", b"c"*chunksize*3, mode="create", chunksize=chunksize)
+        s3.pipe(
+            f"{test_bucket_name}/afile",
+            b"c" * chunksize * 3,
+            mode="create",
+            chunksize=chunksize,
+        )
 
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
-@pytest.mark.xfail(reason="moto doesn't support IfNoneMatch for MPU when object created via MPU")
+@pytest.mark.xfail(
+    reason="moto doesn't support IfNoneMatch for MPU when object created via MPU"
+)
 def test_put_exclusive_big(s3, tmpdir):
     chunksize = 5 * 2**20  # minimum allowed
     fn = f"{tmpdir}/afile"
@@ -2934,16 +2945,16 @@ def test_put_exclusive_big(s3, tmpdir):
     s3.put(fn, f"{test_bucket_name}/afile", mode="overwrite", chunksize=chunksize)
     s3.put(fn, f"{test_bucket_name}/afile", mode="overwrite", chunksize=chunksize)
     with pytest.raises(FileExistsError):
-        s3.put(
-            fn, f"{test_bucket_name}/afile", mode="create", chunksize=chunksize
-        )
+        s3.put(fn, f"{test_bucket_name}/afile", mode="create", chunksize=chunksize)
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
-@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
+@pytest.mark.xfail(
+    old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True
+)
 def test_put_exclusive_big_after_small(s3, tmpdir):
     """Test conditional MPU after creating object via put_object.
-    
+
     This test is required because moto's implementation of IfNoneMatch for MPU
     only works when the object is initially created via put_object and not via
     MPU.
@@ -2963,7 +2974,9 @@ def test_put_exclusive_big_after_small(s3, tmpdir):
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
-@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
+@pytest.mark.xfail(
+    old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True
+)
 def test_put_exclusive_small(s3, tmpdir):
     fn = f"{tmpdir}/afile"
     with open(fn, "wb") as f:

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -18,6 +18,7 @@ from itertools import chain
 import fsspec.core
 from dateutil.tz import tzutc
 
+import botocore
 import s3fs.core
 from s3fs.core import S3FileSystem
 from s3fs.utils import ignoring, SSEParams
@@ -2888,6 +2889,11 @@ def test_exist_after_delete(s3):
     assert not s3.exists(test_dir)
 
 
+# condition: True if running on botocore < 1.33.0
+# The below tests for exclusive writes 
+old_botocore = version.parse(botocore.__version__) < version.parse("1.33.0")
+
+
 @pytest.mark.xfail(reason="moto doesn't support IfNoneMatch for MPU when object created via MPU")
 def test_pipe_exclusive_big(s3):
     chunksize = 5 * 2**20  # minimum allowed
@@ -2899,6 +2905,7 @@ def test_pipe_exclusive_big(s3):
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
+@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
 def test_pipe_exclusive_big_after_small(s3):
     """Test conditional MPU after creating object via put_object
     
@@ -2933,6 +2940,7 @@ def test_put_exclusive_big(s3, tmpdir):
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
+@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
 def test_put_exclusive_big_after_small(s3, tmpdir):
     """Test conditional MPU after creating object via put_object.
     
@@ -2955,6 +2963,7 @@ def test_put_exclusive_big_after_small(s3, tmpdir):
     assert not s3.list_multipart_uploads(test_bucket_name)
 
 
+@pytest.mark.xfail(old_botocore, reason="botocore<1.33.0 lacks IfNoneMatch support", strict=True)
 def test_put_exclusive_small(s3, tmpdir):
     fn = f"{tmpdir}/afile"
     with open(fn, "wb") as f:


### PR DESCRIPTION
Prior to this change the exclusive write mode "x" did not behave properly for small files, instead acting the same as "w".

This change solves that by passing the IfNotMatch header to put_object even when writing small files that don't require a multipart upload.

Fixes https://github.com/fsspec/s3fs/issues/973

Tested by running the test script linked in the issue as well as updating the unit tests.