### PR TITLE
If no key get bucket info

### DIFF
--- a/s3fs/core.py
+++ b/s3fs/core.py
@@ -1464,6 +1464,18 @@ class S3FileSystem(AsyncFileSystem):
                 pass
             except ClientError as e:
                 raise translate_boto_error(e, set_cause=False)
+        else:
+            try:
+                out = await self._call_s3("head_bucket", Bucket=bucket, **self.req_kw)
+                return {
+                    "name": bucket,
+                    "type": "directory",
+                    "size": 0,
+                    "StorageClass": "DIRECTORY",
+                    "VersionId": out.get("VersionId"),
+                }
+            except ClientError as e:
+                raise translate_boto_error(e, set_cause=False)
 
         try:
             # We check to see if the path is a directory by attempting to list its

--- a/s3fs/tests/test_s3fs.py
+++ b/s3fs/tests/test_s3fs.py
@@ -2986,3 +2986,10 @@ def test_put_exclusive_small(s3, tmpdir):
     with pytest.raises(FileExistsError):
         s3.put(fn, f"{test_bucket_name}/afile", mode="create")
     assert not s3.list_multipart_uploads(test_bucket_name)
+
+
+def test_bucket_info(s3):
+    info = s3.info(test_bucket_name)
+    assert "VersionId" in info
+    assert info["type"] == "directory"
+    assert info["name"] == test_bucket_name


### PR DESCRIPTION
In #961 @martindurant mentions that it would be nice to handle the case where no key is specified and use `head_bucket` to gather more information about the bucket. (https://github.com/fsspec/s3fs/pull/961#issuecomment-2847836001)

This PR implements that and returns the `VersionId` for the bucket. Is there anything else that would be useful to include in here?